### PR TITLE
Add optional cloud control: on/off, system mode, backup power (EPS), SOC limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -207,6 +207,37 @@ is:
   is in effect — in Local mode it is inert: measured at 1125 W output inside a
   window the schedule caps at 50 W.
 
+## Example dashboard
+
+The integration creates 44 entities. `examples/` has a dashboard that sorts
+them into something usable — power right now, battery, controls, energy
+totals, alarms, history:
+
+| File | Needs |
+|------|-------|
+| [`examples/dashboard.yaml`](examples/dashboard.yaml) | [Mushroom](https://github.com/piitaya/lovelace-mushroom) and [fold-entity-row](https://github.com/thomasloven/lovelace-fold-entity-row) from HACS |
+| [`examples/dashboard-core.yaml`](examples/dashboard-core.yaml) | nothing — built only from cards Home Assistant ships with |
+
+Same layout either way. Without the two custom cards installed, the first file
+renders "Custom element doesn't exist" where they would be, so take the second
+one if you would rather not install anything.
+
+Settings → Dashboards → Add dashboard → New dashboard from scratch, then paste
+the file into the raw configuration editor (pencil → three dots → Raw
+configuration editor).
+
+**Both files assume the integration was added with the name `ezhi`.** Replace
+that throughout if you used something else — but note the prefixes are not
+uniform: the local sensors are `sensor.ezhi_…`, while the cloud entities and
+the local power number carry an extra `apsystems_`. The exact ids for your
+install are on the device page.
+
+The control section is marked for deletion if you do not use cloud control. It
+is not hidden by a conditional card on purpose: the frontend's condition check
+reads `hass.states[entity]?.state`, so for an entity that does not exist at all
+a `state_not: unavailable` condition evaluates true — the card would appear
+exactly when it should not.
+
 ## API Endpoints
 
 The integration uses the following local API endpoints:

--- a/README.md
+++ b/README.md
@@ -127,13 +127,21 @@ Leave the token fields empty and nothing about the integration changes.
 
 ### Setup
 
-Cloud control needs an EMA `access_token` and `refresh_token`. There is no
-official way to obtain them; they come from the login response of the
-APsystems app (`POST /api/token/generateToken/user/loginEncrypt`), captured
-with an HTTPS proxy. The `refresh_token` does not rotate, so one capture lasts
-until you change your password.
+Go to **Settings → Devices & Services → APsystems EZHI → Configure** and enter
+the e-mail address and password of your APsystems EMA account. The integration
+performs the same login the app does and stores the resulting token pair.
 
-Enter both under **Settings → Devices & Services → APsystems EZHI → Configure**.
+**The password is used once and never stored** — only the tokens are written to
+the config entry, and the `refresh_token` does not rotate, so the login only has
+to succeed once. The account fields stay empty afterwards for that reason; to
+switch accounts, fill them in again.
+
+There is no documented API for this. The login endpoint
+(`POST /api/token/generateToken/user/loginEncrypt`) encrypts the credentials
+client-side: a fresh AES-256 key and IV per login, both RSA-wrapped under a
+public key baked into the app. That scheme is reproduced in `cloud.py` from the
+app's own implementation, so no HTTPS proxy capture is needed. If you already
+have a captured token pair, the two token fields still accept it directly.
 
 ### Entities
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,23 @@ Two writes are refused rather than passed on:
 - **Discharge protection below SOC minimum + 2 %** — otherwise the device
   clamps it silently.
 
+### Known limitations
+
+Two device-side settings are readable in the cloud config but have no known
+write path, and both can make an entity above look more authoritative than it
+is:
+
+- **Winter mode** (`winter`). Per the app's own text, it raises the effective
+  SOC floor to 50 % and the discharge protection to 65 %. It overrides the two
+  `number` entities *without changing them*: on the development install
+  `socMin` reads 10 % while the battery has not been below 53 % in 30 days.
+  The flag appears in no `params` object and under no `setRemote` identifier,
+  so for now it can only be toggled in the app.
+- **The weekly output schedule** (`outputPowerStrategyWeekly`) is read to
+  guard the power limit, and never written. `isOPStrategy: 1` does not mean it
+  is in effect — in Local mode it is inert: measured at 1125 W output inside a
+  window the schedule caps at 50 W.
+
 ## API Endpoints
 
 The integration uses the following local API endpoints:

--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ Leave the token fields empty and nothing about the integration changes.
 ### Setup
 
 Go to **Settings → Devices & Services → APsystems EZHI → Configure** and enter
-the e-mail address and password of your APsystems EMA account. The integration
+the **username** and password of your APsystems EMA account. The integration
 performs the same login the app does and stores the resulting token pair.
+
+> The account **username**, not the e-mail address you may also log in with —
+> `loginEncrypt` rejects the address. Verified against a live account.
 
 **The password is used once and never stored** — only the tokens are written to
 the config entry, and the `refresh_token` does not rotate, so the login only has

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This Home Assistant integration allows you to monitor and control your APsystems
 - **Separate Scan Intervals**: Configure fast polling for power data and slower polling for alarms/device info.
 - **Device Info Panel**: View firmware version, serial number, and direct link to inverter API.
 - **Multi-language Support**: English and German translations included.
+- **Cloud Control (optional)**: On/off, system mode, backup power (EPS), ECO, SOC limits and more — none of which exist in the local API.
 
 ## Prerequisites
 
@@ -108,6 +109,76 @@ After initial setup, you can change the scan intervals without reconfiguring:
 
 - **Max Output Power**: Set the maximum power output of the inverter (-1200W to +1200W)
 
+## Cloud Control (optional)
+
+The local API is read-only apart from `setPower`. On/off, the system mode and
+**backup power (EPS)** are not in it at all — they exist only in the APsystems
+EMA cloud. This integration can talk to that cloud as a second, fully separate
+layer.
+
+**The local side never depends on it.** The cloud runs on its own coordinator:
+dead credentials, an unreachable cloud or a hanging request take out the cloud
+entities only. Every local sensor keeps updating, and Home Assistant offers a
+reauth prompt instead of failing the whole entry. Verified against a live
+install: with a deliberately broken token, all four cloud entities went
+`unavailable` and all 130 local entities kept their values.
+
+Leave the token fields empty and nothing about the integration changes.
+
+### Setup
+
+Cloud control needs an EMA `access_token` and `refresh_token`. There is no
+official way to obtain them; they come from the login response of the
+APsystems app (`POST /api/token/generateToken/user/loginEncrypt`), captured
+with an HTTPS proxy. The `refresh_token` does not rotate, so one capture lasts
+until you change your password.
+
+Enter both under **Settings → Devices & Services → APsystems EZHI → Configure**.
+
+### Entities
+
+| Entity | Type | Notes |
+|--------|------|-------|
+| Inverter On | `switch` | **One-way from HA.** Once off, the inverter drops off the cloud's MQTT link and cannot be turned back on remotely — it needs PV/DC input or a 3 s press on the battery button. |
+| System Mode | `select` | Balcony Storage, Portable, AI, Local, No Battery. Switching to Local is what enables the local API. |
+| Backup Power (EPS) | `switch` | Mutually exclusive with ECO — enabling one clears the other in a single write. |
+| ECO Mode | `switch` | Powers down the off-grid side after an hour with no load. Measured: it does **not** reduce standby draw (~17 W either way). |
+| SOC Minimum / Maximum | `number` | Percent. |
+| Discharge Protection | `number` | Refused below *SOC minimum + 2 %*, the same rule the app enforces. |
+| Preset Output Power | `number` | Watts. |
+| Power Limit | `sensor` | Read-only — see below. |
+
+### High power mode
+
+The output ceiling is 800 W by default and can be raised to 1200 W. The
+APsystems app puts a disclaimer in front of that: it "may cause the device
+output to exceed regulatory limits for grid connection", with the legal risk
+on the operator.
+
+Home Assistant has no confirmation dialog for an entity — a switch is always
+one tap — so this is an action instead:
+
+```yaml
+action: apsystems_ezhi_local.set_high_power_mode
+data:
+  enable: true
+  acknowledge_regulatory_risk: true   # required only when enabling
+```
+
+Lowering the ceiling is refused while the weekly output schedule still has
+entries above it. The vendor app silently rewrites those; this integration
+tells you which ones are in the way and leaves your schedule alone.
+
+### Safety behaviour
+
+Two writes are refused rather than passed on:
+
+- **"No Battery" mode while a battery is connected** — the "battery access
+  conflict" the app warns about. The refusal lifts by itself once the cloud
+  stops reporting a battery.
+- **Discharge protection below SOC minimum + 2 %** — otherwise the device
+  clamps it silently.
+
 ## API Endpoints
 
 The integration uses the following local API endpoints:
@@ -122,6 +193,11 @@ The integration uses the following local API endpoints:
 
 Bruno API collection files are included for testing.
 
+Cloud endpoints live under `https://app.api.apsystemsema.com:9223/aps-api-web/api/v2/`.
+The `/api/v2` segment is not optional: without it every endpoint answers HTTP
+200 with body code 4 "Internal Server Error", which looks like a cloud outage
+rather than a wrong path.
+
 ## Troubleshooting
 
 - **Cannot connect**: Ensure the inverter is connected to your network and local mode is enabled
@@ -129,6 +205,17 @@ Bruno API collection files are included for testing.
 - **Stale data**: Try reducing the update interval in the integration options
 
 ## Changelog
+
+### v0.3.0
+
+- **New: optional cloud control** — on/off, system mode, backup power (EPS),
+  ECO, SOC limits, discharge protection and preset output power, none of which
+  exist in the local API
+- **New:** `set_high_power_mode` action, gated behind an explicit
+  acknowledgement of the vendor's regulatory disclaimer
+- Cloud runs on its own coordinator: a cloud failure cannot take the local
+  sensors down, and dead credentials trigger a reauth prompt
+- 75 unit tests for the cloud client, no network and no Home Assistant needed
 
 ### v0.2.1
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ rather than a wrong path.
 
 ## Changelog
 
-### v0.3.0
+### v0.4.0
 
 - **New: optional cloud control** — on/off, system mode, backup power (EPS),
   ECO, SOC limits, discharge protection and preset output power, none of which
@@ -274,7 +274,13 @@ rather than a wrong path.
   acknowledgement of the vendor's regulatory disclaimer
 - Cloud runs on its own coordinator: a cloud failure cannot take the local
   sensors down, and dead credentials trigger a reauth prompt
-- 75 unit tests for the cloud client, no network and no Home Assistant needed
+- 88 unit tests for the cloud client, no network and no Home Assistant needed
+- Cloud login with the EMA account username and password — no HTTPS proxy
+  capture needed
+- Example dashboard in `examples/`, in a HACS and a built-in-cards variant
+- Both actions take an optional `device_id`; with several inverters set up they
+  refuse rather than silently pick one
+- Minimum Home Assistant version raised to 2024.11
 
 ### v0.2.1
 

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import (
@@ -46,6 +47,47 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SELECT,
 ]
+
+
+def _resolve_entry_data(hass: HomeAssistant, call) -> dict:
+    """Which EZHI a service call is for.
+
+    The services are registered once for the integration, so the handler cannot
+    close over one entry -- with two inverters set up, whichever loaded last
+    would silently win every call. For set_high_power_mode that would mean
+    raising a regulatory ceiling on the wrong device, quietly.
+
+    So: an explicit device_id decides, a single loaded entry is unambiguous,
+    and anything else is refused rather than guessed at.
+    """
+    loaded = {
+        entry.entry_id: entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.entry_id in hass.data.get(DOMAIN, {})
+    }
+    if not loaded:
+        raise HomeAssistantError("no APsystems EZHI device is currently loaded")
+
+    device_id = call.data.get("device_id")
+    if device_id:
+        device = dr.async_get(hass).async_get(device_id)
+        if device is None:
+            raise HomeAssistantError(f"no such device: {device_id}")
+        for entry_id in device.config_entries:
+            if entry_id in loaded:
+                return hass.data[DOMAIN][entry_id]
+        raise HomeAssistantError(
+            f"device {device.name or device_id} does not belong to a loaded "
+            "APsystems EZHI entry"
+        )
+
+    if len(loaded) > 1:
+        raise HomeAssistantError(
+            f"{len(loaded)} APsystems EZHI devices are set up -- pass device_id "
+            "to say which one you mean. This call changes hardware settings, so "
+            "it will not pick one for you."
+        )
+    return next(iter(hass.data[DOMAIN].values()))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -144,6 +186,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Register the set_power service
     async def set_power_service(call):
+        # The local API object of whichever entry this call targets -- not the
+        # one this setup closed over, which would be the last entry loaded.
+        api = _resolve_entry_data(hass, call)["COORDINATOR"].api
         power = call.data["power"]
         _LOGGER.debug("Setting power for %s watts", power)
         if power < MIN_VALUE:
@@ -154,11 +199,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             power = MAX_VALUE
         await api.set_power(power)
 
-    hass.services.async_register(
-        DOMAIN, "set_power", set_power_service, schema=vol.Schema({
-            vol.Required("power"): int,
-        })
-    )
+    if not hass.services.has_service(DOMAIN, "set_power"):
+        hass.services.async_register(
+            DOMAIN, "set_power", set_power_service, schema=vol.Schema({
+                vol.Optional("device_id"): cv.string,
+                vol.Required("power"): int,
+            })
+        )
 
     # High power mode is a service, not a switch entity, and the reason is the
     # disclaimer the vendor app puts in front of it: 1200 W "may cause the
@@ -168,7 +215,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # deliberate act. Hence the acknowledgement, required only in the direction
     # that carries the risk.
     async def set_high_power_mode_service(call):
-        cloud_coordinator = hass.data[DOMAIN][entry.entry_id].get(CLOUD_COORDINATOR)
+        cloud_coordinator = _resolve_entry_data(hass, call).get(CLOUD_COORDINATOR)
         if cloud_coordinator is None:
             raise HomeAssistantError(
                 "high power mode is a cloud setting and no cloud credentials are "
@@ -194,13 +241,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise HomeAssistantError(str(err)) from err
         await cloud_coordinator.async_request_refresh()
 
-    hass.services.async_register(
-        DOMAIN, "set_high_power_mode", set_high_power_mode_service,
-        schema=vol.Schema({
-            vol.Required("enable"): cv.boolean,
-            vol.Optional("acknowledge_regulatory_risk", default=False): cv.boolean,
-        })
-    )
+    if not hass.services.has_service(DOMAIN, "set_high_power_mode"):
+        hass.services.async_register(
+            DOMAIN, "set_high_power_mode", set_high_power_mode_service,
+            schema=vol.Schema({
+                vol.Optional("device_id"): cv.string,
+                vol.Required("enable"): cv.boolean,
+                vol.Optional("acknowledge_regulatory_risk", default=False): cv.boolean,
+            })
+        )
 
     return True
 
@@ -217,6 +266,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        # The services are registered once for the integration, not per entry,
+        # so they have to go when the last entry does. Leaving them behind gave
+        # a KeyError from a handler holding a dead entry_id.
+        if not hass.data[DOMAIN]:
+            for service in ("set_power", "set_high_power_mode"):
+                hass.services.async_remove(DOMAIN, service)
 
     return unload_ok
 

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -121,6 +121,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "EZHI cloud is unreachable at startup; the control entities "
                     "start unavailable and recover on the next successful poll"
                 )
+    elif entry.data.get(CONF_CLOUD_ACCESS_TOKEN):
+        # Half-configured: an access token with no refresh token can never
+        # bootstrap (refreshToken needs both), so the cloud layer is skipped
+        # -- but silently, with no entities and no error, was indistinguishable
+        # from "cloud not configured at all". Name the missing field.
+        _LOGGER.warning(
+            "Cloud control has a cloud_access_token but no "
+            "cloud_refresh_token configured; both are required, so the "
+            "cloud layer is skipped. Add the missing refresh token to "
+            "enable it."
+        )
 
     hass.data[DOMAIN][entry.entry_id] = {
         **entry.data,

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     MAX_VALUE,
     CLOUD_COORDINATOR,
     CONF_CLOUD_ACCESS_TOKEN,
+    CONF_CLOUD_DEVICE_ID,
     CONF_CLOUD_REFRESH_TOKEN,
     CONF_CLOUD_SCAN_INTERVAL,
     DEFAULT_CLOUD_SCAN_INTERVAL,
@@ -41,7 +42,6 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
-    Platform.SELECT,
 ]
 
 
@@ -70,11 +70,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Strictly isolated: every failure path here leaves the local sensors alone.
     cloud_coordinator = None
     if entry.data.get(CONF_CLOUD_REFRESH_TOKEN):
-        device_id = coordinator.device_info.deviceId if coordinator.device_info else ""
+        # Prefer the live deviceId, fall back to the cached one: the local
+        # coordinator swallows a failed get_device_info() and leaves
+        # device_info None, and the deviceId is stable hardware identity, so
+        # one transient local-API failure must not disable the cloud layer
+        # for the entry's whole lifetime.
+        live_device_id = coordinator.device_info.deviceId if coordinator.device_info else ""
+        device_id = live_device_id or entry.data.get(CONF_CLOUD_DEVICE_ID, "")
+        if live_device_id and live_device_id != entry.data.get(CONF_CLOUD_DEVICE_ID):
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, CONF_CLOUD_DEVICE_ID: live_device_id}
+            )
         if not device_id:
             _LOGGER.warning(
-                "Cloud control is configured but the local API returned no "
-                "deviceId — skipping the cloud layer for this run"
+                "Cloud control is configured but no deviceId is known yet "
+                "(the local API returned none and none is cached) — skipping "
+                "the cloud layer for this run. Reloading the integration "
+                "will retry once the local API answers."
             )
         else:
             cloud_api = EzhiCloudApi(
@@ -85,13 +97,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             cloud_coordinator = ApSystemsCloudCoordinator(
                 hass,
+                entry,
                 cloud_api,
                 entry.data.get(CONF_CLOUD_SCAN_INTERVAL, DEFAULT_CLOUD_SCAN_INTERVAL),
             )
             # async_refresh, NOT async_config_entry_first_refresh: the latter
             # raises ConfigEntryNotReady and would tear down the whole entry —
             # local sensors included — over a cloud outage.
-            await cloud_coordinator.async_refresh()
+            # The wrapping deadline keeps a hung cloud off the local sensors'
+            # critical path; async_refresh itself never raises, the timeout does.
+            try:
+                async with asyncio.timeout(20):
+                    await cloud_coordinator.async_refresh()
+            except TimeoutError:
+                _LOGGER.warning(
+                    "EZHI cloud did not answer within 20 s at startup; the "
+                    "control entities start unavailable and recover on the "
+                    "next successful poll"
+                )
             if not cloud_coordinator.last_update_success:
                 _LOGGER.warning(
                     "EZHI cloud is unreachable at startup; the control entities "
@@ -130,7 +153,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["COORDINATOR"]
     coordinator.stop_alarm_timer()
-    
+    # The cloud coordinator (if any) needs no explicit cleanup here:
+    # DataUpdateCoordinator.__init__ already registers
+    # async_on_unload(self.async_shutdown) for itself.
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
@@ -163,7 +189,7 @@ class ApSystemsDataCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            name="APSystems EZHI Data",
+            name="APsystems EZHI Data",
             update_interval=timedelta(seconds=output_interval),
         )
         self.api = api
@@ -308,12 +334,24 @@ class ApSystemsCloudCoordinator(DataUpdateCoordinator):
     outage. Nothing in here may raise into the local coordinator's path.
     """
 
-    def __init__(self, hass: HomeAssistant, api: EzhiCloudApi, interval: int):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        api: EzhiCloudApi,
+        interval: int,
+    ):
         super().__init__(
             hass,
             _LOGGER,
             name="APsystems EZHI Cloud",
             update_interval=timedelta(seconds=interval),
+            # Explicit rather than relying on the current_entry ContextVar:
+            # the reauth flow needs self.config_entry to be set.
+            config_entry=entry,
+            # The cloud config barely changes; don't wake every listener each
+            # poll just to write back an identical dict.
+            always_update=False,
         )
         self.api = api
 
@@ -324,5 +362,9 @@ class ApSystemsCloudCoordinator(DataUpdateCoordinator):
             # Raising this makes HA start a reauth flow instead of retrying a
             # credential that will never work again.
             raise ConfigEntryAuthFailed(str(err)) from err
-        except (EzhiCloudError, client_exceptions.ClientError, TimeoutError) as err:
+        except EzhiCloudError as err:
+            # cloud.py's _http() already wraps every transport failure (and
+            # timeout) into EzhiCloudError itself, so catching it alone is
+            # sufficient here — no separate client_exceptions.ClientError /
+            # TimeoutError arm needed.
             raise UpdateFailed(f"EZHI cloud poll failed: {err}") from err

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -12,7 +12,8 @@ from aiohttp import client_exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -34,6 +35,7 @@ from .const import (
 )
 from .api import APsystemsEZHI, ReturnOutputData, ReturnDeviceInfo, ReturnAlarmData
 from .cloud import EzhiCloudApi, EzhiCloudAuthError, EzhiCloudError
+from .entity import CLOUD_WRITE_TIMEOUT_S
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,6 +157,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_register(
         DOMAIN, "set_power", set_power_service, schema=vol.Schema({
             vol.Required("power"): int,
+        })
+    )
+
+    # High power mode is a service, not a switch entity, and the reason is the
+    # disclaimer the vendor app puts in front of it: 1200 W "may cause the
+    # device output to exceed regulatory limits for grid connection", with the
+    # legal risk on the operator. Home Assistant has no confirmation dialog for
+    # an entity -- a switch is always one tap -- but a service field is a
+    # deliberate act. Hence the acknowledgement, required only in the direction
+    # that carries the risk.
+    async def set_high_power_mode_service(call):
+        cloud_coordinator = hass.data[DOMAIN][entry.entry_id].get(CLOUD_COORDINATOR)
+        if cloud_coordinator is None:
+            raise HomeAssistantError(
+                "high power mode is a cloud setting and no cloud credentials are "
+                "configured for this device"
+            )
+        enable = call.data["enable"]
+        if enable and not call.data.get("acknowledge_regulatory_risk"):
+            raise HomeAssistantError(
+                "enabling high power mode raises the output ceiling to 1200 W, "
+                "which may exceed the regulatory limit for your grid connection. "
+                "Set acknowledge_regulatory_risk: true to confirm you accept "
+                "responsibility for that."
+            )
+        try:
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                await cloud_coordinator.api.async_set_high_power(enable)
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                "-- the power limit change may or may not have been applied"
+            ) from err
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        await cloud_coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN, "set_high_power_mode", set_high_power_mode_service,
+        schema=vol.Schema({
+            vol.Required("enable"): cv.boolean,
+            vol.Optional("acknowledge_regulatory_risk", default=False): cv.boolean,
         })
     )
 

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -42,6 +42,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
+    Platform.SELECT,
 ]
 
 

--- a/custom_components/apsystems_ezhi_local/__init__.py
+++ b/custom_components/apsystems_ezhi_local/__init__.py
@@ -12,8 +12,10 @@ from aiohttp import client_exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import (
     DOMAIN,
     SCAN_INTERVAL_OUTPUT,
@@ -23,8 +25,14 @@ from .const import (
     UPDATE_INTERVAL,
     MIN_VALUE,
     MAX_VALUE,
+    CLOUD_COORDINATOR,
+    CONF_CLOUD_ACCESS_TOKEN,
+    CONF_CLOUD_REFRESH_TOKEN,
+    CONF_CLOUD_SCAN_INTERVAL,
+    DEFAULT_CLOUD_SCAN_INTERVAL,
 )
 from .api import APsystemsEZHI, ReturnOutputData, ReturnDeviceInfo, ReturnAlarmData
+from .cloud import EzhiCloudApi, EzhiCloudAuthError, EzhiCloudError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +41,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
+    Platform.SELECT,
 ]
 
 
@@ -56,8 +65,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data BEFORE setting up platforms
     # This ensures device_info is available for device registration
     await coordinator.async_fetch_initial_data()
-    
-    hass.data[DOMAIN][entry.entry_id] = {**entry.data, "COORDINATOR": coordinator}
+
+    # --- optional cloud control layer ---------------------------------------
+    # Strictly isolated: every failure path here leaves the local sensors alone.
+    cloud_coordinator = None
+    if entry.data.get(CONF_CLOUD_REFRESH_TOKEN):
+        device_id = coordinator.device_info.deviceId if coordinator.device_info else ""
+        if not device_id:
+            _LOGGER.warning(
+                "Cloud control is configured but the local API returned no "
+                "deviceId — skipping the cloud layer for this run"
+            )
+        else:
+            cloud_api = EzhiCloudApi(
+                session=async_get_clientsession(hass),
+                device_id=device_id,
+                access_token=entry.data.get(CONF_CLOUD_ACCESS_TOKEN, ""),
+                refresh_token=entry.data[CONF_CLOUD_REFRESH_TOKEN],
+            )
+            cloud_coordinator = ApSystemsCloudCoordinator(
+                hass,
+                cloud_api,
+                entry.data.get(CONF_CLOUD_SCAN_INTERVAL, DEFAULT_CLOUD_SCAN_INTERVAL),
+            )
+            # async_refresh, NOT async_config_entry_first_refresh: the latter
+            # raises ConfigEntryNotReady and would tear down the whole entry —
+            # local sensors included — over a cloud outage.
+            await cloud_coordinator.async_refresh()
+            if not cloud_coordinator.last_update_success:
+                _LOGGER.warning(
+                    "EZHI cloud is unreachable at startup; the control entities "
+                    "start unavailable and recover on the next successful poll"
+                )
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        **entry.data,
+        "COORDINATOR": coordinator,
+        CLOUD_COORDINATOR: cloud_coordinator,
+    }
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Register the set_power service
@@ -253,3 +298,31 @@ class ApSystemsDataCoordinator(DataUpdateCoordinator):
             or previous_data != self.data
         ):
             self.async_update_listeners()
+
+
+class ApSystemsCloudCoordinator(DataUpdateCoordinator):
+    """Polls the EMA cloud for the controllable configuration.
+
+    Deliberately a second, separate coordinator: the local sensors must keep
+    working when the cloud token dies, the internet drops or APsystems has an
+    outage. Nothing in here may raise into the local coordinator's path.
+    """
+
+    def __init__(self, hass: HomeAssistant, api: EzhiCloudApi, interval: int):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="APsystems EZHI Cloud",
+            update_interval=timedelta(seconds=interval),
+        )
+        self.api = api
+
+    async def _async_update_data(self) -> dict:
+        try:
+            return await self.api.async_get_config()
+        except EzhiCloudAuthError as err:
+            # Raising this makes HA start a reauth flow instead of retrying a
+            # credential that will never work again.
+            raise ConfigEntryAuthFailed(str(err)) from err
+        except (EzhiCloudError, client_exceptions.ClientError, TimeoutError) as err:
+            raise UpdateFailed(f"EZHI cloud poll failed: {err}") from err

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -134,6 +134,10 @@ class EzhiCloudApi:
             raise
         except (TypeError, AttributeError, NameError, KeyError, IndexError):
             raise                      # our bug, not the network's
+        except TimeoutError as err:
+            raise EzhiCloudError(
+                f"the EZHI cloud did not respond within {self._timeout}s: {err!r}"
+            ) from err
         except Exception as err:
             raise EzhiCloudError(
                 f"transport failure talking to the EZHI cloud: {err!r}"
@@ -198,6 +202,10 @@ class EzhiCloudApi:
             raise
         except (TypeError, AttributeError, NameError, KeyError, IndexError):
             raise                      # our bug, not the network's
+        except TimeoutError as err:
+            raise EzhiCloudError(
+                f"the EZHI cloud did not respond within {self._timeout}s: {err!r}"
+            ) from err
         except Exception as err:
             raise EzhiCloudError(
                 f"transport failure talking to the EZHI cloud: {err!r}"

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -21,8 +21,9 @@ API_URL = f"{BASE_URL}/aps-api-web"
 TOKEN_URL = f"{BASE_URL}/api/token/refreshToken"
 
 # The JWT lives 2 h. Refresh well before that rather than waiting for a 401 —
-# the 401 path stays as the backstop.
-TOKEN_TTL_SECONDS = 6000
+# the 401 path stays as the backstop. This is our refresh cadence, not the
+# token's actual lifetime.
+TOKEN_REFRESH_AFTER_SECONDS = 6000
 
 # The cloud reports a dead refresh_token as one of these.
 AUTH_ERROR_CODES = {3000, 3001, 3002, 3003, 3004}
@@ -95,7 +96,7 @@ class EzhiCloudApi:
         refresh_token: str,
         language: str = "en",
         timeout: int = 15,
-    ):
+    ) -> None:
         self._session = session
         self._device_id = device_id
         # Bootstrap bearer from the capture. refreshToken accepts an expired one,
@@ -109,7 +110,7 @@ class EzhiCloudApi:
 
     # --- token handling ---------------------------------------------------
 
-    async def _refresh_token_now(self) -> None:
+    async def _fetch_access_token(self) -> None:
         """Exchange the refresh_token for a new access_token.
 
         The refresh_token does not rotate, so it is never overwritten here.
@@ -149,7 +150,7 @@ class EzhiCloudApi:
             raise EzhiCloudAuthError("refreshToken returned no access_token")
 
         self._token = token
-        self._token_expires = time.monotonic() + TOKEN_TTL_SECONDS
+        self._token_expires = time.monotonic() + TOKEN_REFRESH_AFTER_SECONDS
         _LOGGER.debug("EZHI cloud: access token refreshed")
 
     async def _ensure_token(self) -> None:
@@ -159,11 +160,13 @@ class EzhiCloudApi:
             # Another task may have refreshed while we waited for the lock.
             if time.monotonic() < self._token_expires:
                 return
-            await self._refresh_token_now()
+            await self._fetch_access_token()
 
     # --- request plumbing -------------------------------------------------
 
-    async def _raw(self, method, path, params, data) -> tuple[int, dict]:
+    async def _send_once(
+        self, method: str, path: str, params: dict | None, data: dict | None
+    ) -> tuple[int, dict]:
         url = f"{API_URL}/{path.lstrip('/')}"
         # Everything coming out of session.request/response.json below is a
         # transport failure by definition -- we cannot import aiohttp here to
@@ -207,7 +210,7 @@ class EzhiCloudApi:
         # this can't compound -- add a wrapping deadline only if it ever does.
         await self._ensure_token()
         token_used = self._token
-        status, body = await self._raw(method, path, params, data)
+        status, body = await self._send_once(method, path, params, data)
 
         if status == 401:
             async with self._lock:
@@ -216,7 +219,7 @@ class EzhiCloudApi:
                 if self._token == token_used:
                     self._token_expires = 0.0
             await self._ensure_token()
-            status, body = await self._raw(method, path, params, data)
+            status, body = await self._send_once(method, path, params, data)
 
         if status == 401:
             raise EzhiCloudAuthError(

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -1,0 +1,163 @@
+"""Cloud control client for the APsystems EZHI (EMA cloud).
+
+Control commands are cloud-only: the local HTTP API exposes five read endpoints
+plus setPower and nothing else. Verified exhaustively 2026-07-30/31, see
+docs/ezhi-cloud-api-map.md for every endpoint and payload used here.
+
+Deliberately free of homeassistant imports so it can be unit-tested standalone.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://app.api.apsystemsema.com:9223"
+API_URL = f"{BASE_URL}/aps-api-web"
+TOKEN_URL = f"{BASE_URL}/api/token/refreshToken"
+
+# The JWT lives 2 h. Refresh well before that rather than waiting for a 401 —
+# the 401 path stays as the backstop.
+TOKEN_TTL_SECONDS = 6000
+
+# The cloud reports a dead refresh_token as one of these.
+AUTH_ERROR_CODES = {3000, 3001, 3002, 3003, 3004}
+# The device is not reachable over MQTT.
+DEVICE_OFFLINE_CODE = 1001
+
+
+class EzhiCloudError(Exception):
+    """A cloud call failed: transport, HTTP status or a non-zero body code."""
+
+
+class EzhiCloudAuthError(EzhiCloudError):
+    """The refresh_token is dead — the user has to capture a new one."""
+
+
+class EzhiCloudOfflineError(EzhiCloudError):
+    """The inverter is not reachable by the cloud (MQTT disconnected)."""
+
+
+class EzhiCloudApi:
+    """Authenticated client for the EMA cloud control endpoints."""
+
+    def __init__(
+        self,
+        session: Any,
+        device_id: str,
+        access_token: str,
+        refresh_token: str,
+        language: str = "en",
+        timeout: int = 15,
+    ):
+        self._session = session
+        self._device_id = device_id
+        # Bootstrap bearer from the capture. refreshToken accepts an expired one,
+        # which is the only reason a single capture keeps working forever.
+        self._token = access_token
+        self._refresh_token = refresh_token
+        self._language = language
+        self._timeout = timeout
+        self._token_expires = 0.0  # forces a refresh on the first call
+        self._lock = asyncio.Lock()
+
+    # --- token handling ---------------------------------------------------
+
+    async def _refresh_token_now(self) -> None:
+        """Exchange the refresh_token for a new access_token.
+
+        The refresh_token does not rotate, so it is never overwritten here.
+        """
+        async with asyncio.timeout(self._timeout):
+            response = await self._session.request(
+                "POST",
+                TOKEN_URL,
+                data={"refresh_token": self._refresh_token,
+                      "language": self._language},
+                headers={"Authorization": f"Bearer {self._token}",
+                         "Accept-Language": self._language},
+            )
+            status = response.status
+            body = await response.json(content_type=None)
+
+        code = body.get("code")
+        if status != 200 or code in AUTH_ERROR_CODES:
+            raise EzhiCloudAuthError(
+                f"refreshToken rejected (HTTP {status}, code {code}): the stored "
+                "refresh_token is no longer valid — capture a new one from the app"
+            )
+        if code != 0:
+            raise EzhiCloudError(
+                f"refreshToken failed: code={code} msg={body.get('message')}"
+            )
+
+        token = (body.get("data") or {}).get("access_token")
+        if not token:
+            raise EzhiCloudAuthError("refreshToken returned no access_token")
+
+        self._token = token
+        self._token_expires = time.monotonic() + TOKEN_TTL_SECONDS
+        _LOGGER.debug("EZHI cloud: access token refreshed")
+
+    async def _ensure_token(self) -> None:
+        if time.monotonic() < self._token_expires:
+            return
+        async with self._lock:
+            # Another task may have refreshed while we waited for the lock.
+            if time.monotonic() < self._token_expires:
+                return
+            await self._refresh_token_now()
+
+    # --- request plumbing -------------------------------------------------
+
+    async def _raw(self, method, path, params, data) -> tuple[int, dict]:
+        url = f"{API_URL}/{path.lstrip('/')}"
+        async with asyncio.timeout(self._timeout):
+            response = await self._session.request(
+                method,
+                url,
+                params=params,
+                data=data,
+                headers={"Authorization": f"Bearer {self._token}",
+                         "Accept-Language": self._language},
+            )
+            if response.status != 200:
+                return response.status, {}
+            return response.status, await response.json(content_type=None)
+
+    async def _call(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+        data: dict | None = None,
+    ) -> dict:
+        """One authenticated call. A 401 buys exactly one refresh + retry."""
+        await self._ensure_token()
+        status, body = await self._raw(method, path, params, data)
+
+        if status == 401:
+            self._token_expires = 0.0
+            await self._ensure_token()
+            status, body = await self._raw(method, path, params, data)
+
+        if status != 200:
+            raise EzhiCloudError(f"{method} {path} -> HTTP {status}")
+
+        code = body.get("code")
+        if code == DEVICE_OFFLINE_CODE:
+            raise EzhiCloudOfflineError(
+                f"{method} {path} -> the inverter is offline (code {code})"
+            )
+        if code in AUTH_ERROR_CODES:
+            raise EzhiCloudAuthError(f"{method} {path} -> auth code {code}")
+        if code != 0:
+            raise EzhiCloudError(
+                f"{method} {path} -> code={code} msg={body.get('message')}"
+            )
+
+        return body.get("data") or {}

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -486,7 +486,8 @@ async def async_login(
     if code != 0:
         raise EzhiCloudAuthError(
             f"login rejected by the EZHI cloud (code={code}): "
-            f"{body.get('message') or 'check the email address and password'}"
+            f"{body.get('message') or 'check the username -- the account username, '
+                                     'not the e-mail address -- and the password'}"
         )
 
     data = body.get("data") or {}

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -126,7 +126,10 @@ class EzhiCloudApi:
                              "Accept-Language": self._language},
                 )
                 status = response.status
-                body = await response.json(content_type=None)
+                try:
+                    body = await response.json(content_type=None)
+                except ValueError:
+                    body = {}
         except EzhiCloudError:
             raise
         except Exception as err:

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -99,17 +99,24 @@ class EzhiCloudApi:
 
         The refresh_token does not rotate, so it is never overwritten here.
         """
-        async with asyncio.timeout(self._timeout):
-            response = await self._session.request(
-                "POST",
-                TOKEN_URL,
-                data={"refresh_token": self._refresh_token,
-                      "language": self._language},
-                headers={"Authorization": f"Bearer {self._token}",
-                         "Accept-Language": self._language},
-            )
-            status = response.status
-            body = await response.json(content_type=None)
+        try:
+            async with asyncio.timeout(self._timeout):
+                response = await self._session.request(
+                    "POST",
+                    TOKEN_URL,
+                    data={"refresh_token": self._refresh_token,
+                          "language": self._language},
+                    headers={"Authorization": f"Bearer {self._token}",
+                             "Accept-Language": self._language},
+                )
+                status = response.status
+                body = await response.json(content_type=None)
+        except EzhiCloudError:
+            raise
+        except Exception as err:
+            raise EzhiCloudError(
+                f"transport failure talking to the EZHI cloud: {err!r}"
+            ) from err
 
         code = body.get("code")
         if status != 200 or code in AUTH_ERROR_CODES:
@@ -143,18 +150,33 @@ class EzhiCloudApi:
 
     async def _raw(self, method, path, params, data) -> tuple[int, dict]:
         url = f"{API_URL}/{path.lstrip('/')}"
-        async with asyncio.timeout(self._timeout):
-            response = await self._session.request(
-                method,
-                url,
-                params=params,
-                data=data,
-                headers={"Authorization": f"Bearer {self._token}",
-                         "Accept-Language": self._language},
-            )
-            if response.status != 200:
-                return response.status, {}
-            return response.status, await response.json(content_type=None)
+        # Everything coming out of session.request/response.json below is a
+        # transport failure by definition -- we cannot import aiohttp here to
+        # catch its ClientError family by name, so this catches broadly and
+        # re-wraps. EzhiCloudError itself is deliberately passed through
+        # unchanged (nothing inside this block raises one today, but the
+        # guard keeps a future change from getting double-wrapped).
+        try:
+            async with asyncio.timeout(self._timeout):
+                response = await self._session.request(
+                    method,
+                    url,
+                    params=params,
+                    data=data,
+                    headers={"Authorization": f"Bearer {self._token}",
+                             "Accept-Language": self._language},
+                )
+                try:
+                    body = await response.json(content_type=None)
+                except ValueError:
+                    body = {}
+                return response.status, body
+        except EzhiCloudError:
+            raise
+        except Exception as err:
+            raise EzhiCloudError(
+                f"transport failure talking to the EZHI cloud: {err!r}"
+            ) from err
 
     async def _call(
         self,

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -132,6 +132,8 @@ class EzhiCloudApi:
                     body = {}
         except EzhiCloudError:
             raise
+        except (TypeError, AttributeError, NameError, KeyError, IndexError):
+            raise                      # our bug, not the network's
         except Exception as err:
             raise EzhiCloudError(
                 f"transport failure talking to the EZHI cloud: {err!r}"
@@ -194,6 +196,8 @@ class EzhiCloudApi:
                 return response.status, body
         except EzhiCloudError:
             raise
+        except (TypeError, AttributeError, NameError, KeyError, IndexError):
+            raise                      # our bug, not the network's
         except Exception as err:
             raise EzhiCloudError(
                 f"transport failure talking to the EZHI cloud: {err!r}"

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -1,8 +1,13 @@
 """Cloud control client for the APsystems EZHI (EMA cloud).
 
 Control commands are cloud-only: the local HTTP API exposes five read endpoints
-plus setPower and nothing else. Verified exhaustively 2026-07-30/31, see
-docs/ezhi-cloud-api-map.md for every endpoint and payload used here.
+plus setPower and nothing else. Verified exhaustively 2026-07-30/31.
+
+Endpoint paths and the systemMode field vocabulary come from the vendor
+app's own bundled API client, not from a packet capture: see
+docs/ezhi-cloud-api-from-app-source.md. Where that contradicts the older
+docs/ezhi-cloud-api-map.md, the app source wins -- the map's base URL was
+transcribed without the /api/v2 segment.
 
 Deliberately free of homeassistant imports so it can be unit-tested standalone.
 """
@@ -50,13 +55,17 @@ class EzhiCloudOfflineError(EzhiCloudError):
     """The inverter is not reachable by the cloud (MQTT disconnected)."""
 
 
-# Whether the systemMode POST merges into the cloud's existing params or
-# replaces the whole blob is unresolved. The evidence points at merge -- the
-# captured app payload for "back to Local" was just {"systemMode":"4",
-# "stayOn":"0"} and a config-GET right after still showed EPS:1 (backup
-# stayed enabled) -- but nothing here rules out replace. Carrying every
-# field we know about is harmless if it merges and essential if it
-# replaces, so both branches below do it either way.
+# The systemMode POST MERGES into the cloud's existing params, it does not
+# replace the blob. Settled 2026-08-01 from two independent directions: the
+# vendor app sends a different, partial field set per mode (mode 4 sends only
+# systemMode/stayOn/thirdLink, mode 3 sometimes only systemMode/tax), which
+# under replace semantics would wipe SOC bounds and EPS on every mode switch
+# in the app itself; and a live mode-4 write from the app left EPS,
+# dischargeProtection, socMin/socMax and powerLimit all untouched.
+#
+# Carrying these forward is therefore belt-and-braces rather than load-
+# bearing. It stays because re-writing a just-read value costs nothing --
+# but see SYSTEM_MODE_SETTABLE_KEYS for the case where it costs plenty.
 #
 # Required: a config that doesn't have these yet is refused rather than
 # guessed at, since a wrong guess drives real hardware and all four always
@@ -64,8 +73,71 @@ class EzhiCloudOfflineError(EzhiCloudError):
 SYSTEM_MODE_KEYS = ("systemMode", "EPS", "ECO", "userSetPower")
 # Carried forward when present, never required: dischargeProtection is a real
 # battery deep-discharge floor (live value seen: 12%), and a config lacking
-# any of these four must not block a mode write.
+# any of these must not block a mode write.
+#
+# The full write vocabulary comes from the vendor app's own payload builders
+# (docs/ezhi-cloud-api-from-app-source.md). Deliberately NOT included:
+# outputPowerStrategy and outputPowerStrategyWeekly. Those are lists, and
+# every value here goes through wire_str -- carrying a schedule forward as
+# str(list) would corrupt it.
 SYSTEM_MODE_OPTIONAL_KEYS = ("dischargeProtection", "stayOn", "governmentLevies", "area")
+
+# Accepted in `changes`, but deliberately NOT carried forward on their own.
+#
+# powerLimit is why this third category exists. The POST hardcodes
+# maxPowerFlag="0", and the device only permits a limit above 800 W while the
+# app's high-power mode is on. Carrying a live powerLimit of 1200 into an
+# unrelated mode switch would therefore re-assert 1200 under a flag that says
+# "standard power" -- and a device that clamps that to 800 would silently cut
+# the output ceiling on a change the user never made. Under the merge
+# semantics the cloud actually has, carrying it buys nothing anyway.
+#
+# singlePhase and thirdLink are topology, not preferences: re-writing them
+# from a poll is pointless and their coupling to the rest is unverified.
+SYSTEM_MODE_SETTABLE_KEYS = ("powerLimit", "singlePhase", "thirdLink", "socMin")
+
+# The firmware treats ECO and EPS as mutually exclusive: ECO=1 forces EPS=0
+# (verified 2026-07-31). Both always travel in one write so the pair can never
+# be observed, even briefly, in a state the device would not accept.
+ECO_EPS_EXCLUSIVE = True
+
+# The app's own rule for the deep-discharge floor: "the effective discharge
+# protection threshold must be at least 2% above the configured minimum SOC".
+DISCHARGE_PROTECTION_MARGIN = 2
+
+
+def _as_int(value: Any) -> int | None:
+    """Best-effort int from a cloud field, which is a string more often than not."""
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _check_discharge_protection(config: dict, changes: dict) -> None:
+    """Refuse a deep-discharge floor the device would silently clamp.
+
+    The vendor app enforces `dischargeProtection >= socMin + 2` and this write
+    path is the only other way in. Checked against the config that was just
+    re-read, so a socMin changed from the app a minute ago still counts.
+
+    Only checks when the caller is actually moving one of the two -- a mode
+    switch that merely carries an already-out-of-range pair forward must not
+    be blocked by a value it did not set.
+    """
+    if "dischargeProtection" not in changes and "socMin" not in changes:
+        return
+    floor = _as_int(changes.get("dischargeProtection", config.get("dischargeProtection")))
+    soc_min = _as_int(changes.get("socMin", config.get("socMin")))
+    if floor is None or soc_min is None:
+        return
+    if floor < soc_min + DISCHARGE_PROTECTION_MARGIN:
+        raise EzhiCloudError(
+            f"discharge protection {floor}% must be at least "
+            f"{DISCHARGE_PROTECTION_MARGIN}% above the minimum SOC ({soc_min}%) "
+            f"-- use {soc_min + DISCHARGE_PROTECTION_MARGIN}% or higher, or lower "
+            "the minimum SOC first"
+        )
 
 
 def wire_str(value: Any) -> str:
@@ -160,7 +232,8 @@ def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     SYSTEM_MODE_KEYS for why both required-and-strict and optional-and-best-
     effort are correct for the same unresolved merge-vs-replace question.
     """
-    known_fields = set(SYSTEM_MODE_KEYS) | set(SYSTEM_MODE_OPTIONAL_KEYS)
+    known_fields = (set(SYSTEM_MODE_KEYS) | set(SYSTEM_MODE_OPTIONAL_KEYS)
+                    | set(SYSTEM_MODE_SETTABLE_KEYS))
     unknown = set(changes) - known_fields
     if unknown:
         raise EzhiCloudError(f"unknown systemMode field(s) {sorted(unknown)}")
@@ -447,6 +520,7 @@ class EzhiCloudApi:
         undo a change made from the vendor app in the meantime.
         """
         config = await self.async_get_config()
+        _check_discharge_protection(config, changes)
         params = build_system_mode_params(config, **changes)
         data = await self._call(
             "POST",
@@ -462,6 +536,31 @@ class EzhiCloudApi:
         )
         if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(f"the inverter rejected systemMode={params}: {data}")
+
+    async def async_set_backup_power(self, on: bool) -> None:
+        """Turn EPS (backup / emergency power) on or off.
+
+        Enabling backup also clears ECO in the same write: the firmware treats
+        them as mutually exclusive, so sending EPS alone would leave the pair
+        in a state the device rejects or silently corrects. Disabling backup
+        does NOT set ECO -- off is off, not "switch to the other one".
+
+        Note the vendor app only exposes this in modes 1, 2 and 5; in Local
+        mode (4) it shows no backup switch, though the field keeps its value.
+        Whether a write lands there is unverified, so nothing here pretends it
+        did: the caller's post-write re-read is the only confirmation.
+        """
+        changes = {"EPS": "1", "ECO": "0"} if on else {"EPS": "0"}
+        await self.async_set_system_mode(**changes)
+
+    async def async_set_eco(self, on: bool) -> None:
+        """Turn ECO mode on or off, clearing EPS when enabling it.
+
+        Mirror image of async_set_backup_power -- see there for why the pair
+        travels together.
+        """
+        changes = {"ECO": "1", "EPS": "0"} if on else {"ECO": "0"}
+        await self.async_set_system_mode(**changes)
 
     async def async_set_soc_limit(
         self, soc_min: int | None = None, soc_max: int | None = None

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -84,13 +84,17 @@ SYSTEM_MODE_OPTIONAL_KEYS = ("dischargeProtection", "stayOn", "governmentLevies"
 
 # Accepted in `changes`, but deliberately NOT carried forward on their own.
 #
-# powerLimit is why this third category exists. The POST hardcodes
-# maxPowerFlag="0", and the device only permits a limit above 800 W while the
-# app's high-power mode is on. Carrying a live powerLimit of 1200 into an
-# unrelated mode switch would therefore re-assert 1200 under a flag that says
-# "standard power" -- and a device that clamps that to 800 would silently cut
-# the output ceiling on a change the user never made. Under the merge
-# semantics the cloud actually has, carrying it buys nothing anyway.
+# powerLimit is why this third category exists. It is the high-power setting
+# (800 vs 1200 W), and 1200 W is the one the app gates behind a disclaimer
+# about exceeding regulatory feed-in limits. Carrying it forward would re-
+# assert that value on every unrelated mode switch or SOC edit -- turning a
+# deliberate, acknowledged choice into something the integration keeps
+# re-asserting on the user's behalf, and putting it on the wire during writes
+# that have nothing to do with it. Under the merge semantics the cloud actually
+# has, carrying it buys nothing anyway: the cloud keeps the value regardless.
+#
+# Set it only through async_set_high_power, which is what the acknowledgement
+# gate in the service handler guards.
 #
 # singlePhase and thirdLink are topology, not preferences: re-writing them
 # from a poll is pointless and their coupling to the rest is unverified.
@@ -104,6 +108,63 @@ ECO_EPS_EXCLUSIVE = True
 # The app's own rule for the deep-discharge floor: "the effective discharge
 # protection threshold must be at least 2% above the configured minimum SOC".
 DISCHARGE_PROTECTION_MARGIN = 2
+
+# "High power mode" in the vendor app is nothing but these two values of
+# powerLimit -- currentPower is only ever assigned minPower or maxPower, never
+# anything between. maxPowerFlag stays "0" either way; the app never sets it to
+# "1" anywhere in its bundle, and remote/ezInverter/maxPower/{userId} is a GET
+# that asks what ceiling this account is allowed, not a write.
+#
+# 1200 is the app's built-in maxPower default. It can in principle be lowered
+# per account by that GET, so a device that clamps 1200 to something else is
+# possible -- the post-write re-read is what tells the truth.
+STANDARD_POWER_LIMIT = 800
+HIGH_POWER_LIMIT = 1200
+
+
+def weekly_schedule_powers(config: dict) -> list[int]:
+    """The watt values encoded in the weekly output schedule.
+
+    Format decoded from the app's own strategy handling: HHMMSS start, HHMMSS
+    end, one mode digit, then four digits of watts --
+    "07000021000020050" is 07:00:00-21:00:00, mode 2, 50 W. Only the trailing
+    power is needed here, so nothing else is parsed and a string that does not
+    fit the shape is skipped rather than guessed at.
+    """
+    powers = []
+    for block in config.get("outputPowerStrategyWeekly") or []:
+        if not isinstance(block, dict):
+            continue
+        for entry in block.get("strategy") or []:
+            text = str(entry)
+            if len(text) >= 4 and text[-4:].isdigit():
+                powers.append(int(text[-4:]))
+    return powers
+
+
+def _check_power_limit_vs_schedule(config: dict, changes: dict) -> None:
+    """Refuse a power limit that would leave schedule entries above the ceiling.
+
+    The vendor app handles this by silently rewriting every schedule entry
+    above the new limit down to it. This refuses instead. Two reasons: a
+    schedule the user built is not ours to rewrite as a side effect of a
+    different setting, and we have never written an outputPowerStrategyWeekly
+    to this cloud -- doing it for the first time inside an unrelated call, on
+    a format decoded by inspection, is how schedules get corrupted.
+    """
+    if "powerLimit" not in changes:
+        return
+    limit = _as_int(changes["powerLimit"])
+    if limit is None:
+        return
+    over = sorted({p for p in weekly_schedule_powers(config) if p > limit})
+    if over:
+        raise EzhiCloudError(
+            f"refusing to set the power limit to {limit} W: the weekly output "
+            f"schedule still has entries at {', '.join(f'{p} W' for p in over)}. "
+            "Lower those in the APsystems app first -- this integration will not "
+            "rewrite a schedule as a side effect of a power-limit change"
+        )
 
 
 def _as_int(value: Any) -> int | None:
@@ -521,6 +582,7 @@ class EzhiCloudApi:
         """
         config = await self.async_get_config()
         _check_discharge_protection(config, changes)
+        _check_power_limit_vs_schedule(config, changes)
         params = build_system_mode_params(config, **changes)
         data = await self._call(
             "POST",
@@ -562,6 +624,23 @@ class EzhiCloudApi:
         """
         changes = {"ECO": "1", "EPS": "0"} if on else {"ECO": "0"}
         await self.async_set_system_mode(**changes)
+
+    async def async_set_high_power(self, enable: bool) -> None:
+        """Switch the output ceiling between 800 W and 1200 W.
+
+        This is the app's "high power mode", which is not a mode at all -- just
+        these two values of powerLimit. Enabling it carries the app's own
+        disclaimer: 1200 W "may cause the device output to exceed regulatory
+        limits for grid connection", with the legal risk on the operator. The
+        acknowledgement gate lives in the service handler, not here, so any
+        other caller has to make that decision explicitly too.
+
+        Lowering back to 800 W is refused while the weekly schedule still has
+        entries above it -- see _check_power_limit_vs_schedule.
+        """
+        await self.async_set_system_mode(
+            powerLimit=HIGH_POWER_LIMIT if enable else STANDARD_POWER_LIMIT
+        )
 
     async def async_set_soc_limit(
         self, soc_min: int | None = None, soc_max: int | None = None

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -42,6 +42,33 @@ class EzhiCloudOfflineError(EzhiCloudError):
     """The inverter is not reachable by the cloud (MQTT disconnected)."""
 
 
+# The systemMode POST replaces the whole params blob. Anything left out risks
+# being defaulted away by the cloud — so every field we know about travels along.
+SYSTEM_MODE_KEYS = ("systemMode", "EPS", "ECO", "userSetPower")
+
+
+def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
+    """Read-modify-write: carry the current config forward, override `changes`.
+
+    `config` is the payload of a systemMode GET. Raises rather than defaulting a
+    missing field — a wrong guess here would reconfigure real hardware.
+    """
+    params = {
+        key: str(config[key])
+        for key in SYSTEM_MODE_KEYS
+        if config.get(key) is not None
+    }
+    params.update({key: str(value) for key, value in changes.items()})
+
+    missing = [key for key in SYSTEM_MODE_KEYS if key not in params]
+    if missing:
+        raise EzhiCloudError(
+            f"cannot build a systemMode payload, the cloud config is missing "
+            f"{missing} — refusing to write a partial configuration"
+        )
+    return params
+
+
 class EzhiCloudApi:
     """Authenticated client for the EMA cloud control endpoints."""
 
@@ -161,3 +188,18 @@ class EzhiCloudApi:
             )
 
         return body.get("data") or {}
+
+    # --- public API -------------------------------------------------------
+
+    async def async_get_config(self) -> dict:
+        """The full controllable config.
+
+        One GET covers everything v1 needs: onOff, systemMode, EPS, ECO,
+        socMin, socMax. There is a separate socLimit GET, but it is a subset.
+        """
+        return await self._call(
+            "GET",
+            "remote/ezInverter/systemMode",
+            params={"deviceId": self._device_id, "type": "EZHI",
+                    "language": self._language},
+        )

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -213,6 +213,12 @@ class EzhiCloudApi:
         status, body = await self._send_once(method, path, params, data)
 
         if status == 401:
+            # ponytail: this capture-then-invalidate dance is untested -- no
+            # dedicated test drives two concurrent callers into a 401 at the
+            # same time. Left uncovered deliberately: the failure mode if it
+            # regressed is a couple of wasted refresh calls, not a loop or a
+            # correctness bug, and building the interleaving needed to hit
+            # this window on purpose wasn't judged worth the ceremony.
             async with self._lock:
                 # Only invalidate if nobody else refreshed while we waited --
                 # otherwise a concurrent caller's fresh token gets discarded.

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -149,6 +149,12 @@ def weekly_schedule_powers(config: dict) -> list[int]:
     fit the shape is skipped rather than guessed at.
     """
     powers = []
+    # Only the weekly schedule. The daily outputPowerStrategy is deliberately
+    # not parsed here: its entries were empty on every config seen, so the watt
+    # encoding is unverified, and guessing at it would either miss entries or
+    # invent them. A daily entry above a newly lowered ceiling would therefore
+    # slip past _check_power_limit_vs_schedule -- worth a capture before anyone
+    # relies on that guard being exhaustive.
     for block in config.get("outputPowerStrategyWeekly") or []:
         if not isinstance(block, dict):
             continue
@@ -535,6 +541,12 @@ class EzhiCloudApi:
         self._timeout = timeout
         self._token_expires = 0.0  # forces a refresh on the first call
         self._lock = asyncio.Lock()
+        # Separate from the token lock, and held across a whole read-modify-
+        # write. Both write paths GET the config, change a field and POST the
+        # result; two of them interleaving means the second POST carries the
+        # first one's pre-change read, and both report success. Setting SOC
+        # minimum and maximum in quick succession is enough to hit it.
+        self._write_lock = asyncio.Lock()
 
     # --- HTTP plumbing ------------------------------------------------------
 
@@ -739,22 +751,23 @@ class EzhiCloudApi:
         poll can be up to a minute old, and writing a stale EPS/ECO back would
         undo a change made from the vendor app in the meantime.
         """
-        config = await self.async_get_config()
-        _check_discharge_protection(config, changes)
-        _check_power_limit_vs_schedule(config, changes)
-        params = build_system_mode_params(config, **changes)
-        data = await self._call(
-            "POST",
-            "remote/ezInverter/systemMode",
-            data={
-                "deviceId": self._device_id,
-                "type": "EZHI",
-                "identifierType": "1",
-                "maxPowerFlag": "0",
-                "language": self._language,
-                "params": json.dumps(params),
-            },
-        )
+        async with self._write_lock:
+            config = await self.async_get_config()
+            _check_discharge_protection(config, changes)
+            _check_power_limit_vs_schedule(config, changes)
+            params = build_system_mode_params(config, **changes)
+            data = await self._call(
+                "POST",
+                "remote/ezInverter/systemMode",
+                data={
+                    "deviceId": self._device_id,
+                    "type": "EZHI",
+                    "identifierType": "1",
+                    "maxPowerFlag": "0",
+                    "language": self._language,
+                    "params": json.dumps(params),
+                },
+            )
         if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(f"the inverter rejected systemMode={params}: {data}")
 
@@ -826,34 +839,35 @@ class EzhiCloudApi:
             # The caller already gave us everything needed to judge the window,
             # so an impossible one is refused without touching the network.
             _check_soc_window(_to_int(soc_min, "socMin"), _to_int(soc_max, "socMax"))
-        config = await self.async_get_config()
-        if soc_min is None:
-            soc_min = config.get("socMin")
-        if soc_max is None:
-            soc_max = config.get("socMax")
-        if soc_min is None or soc_max is None:
-            raise EzhiCloudError(
-                "cannot build a socLimit payload, the cloud config is missing "
-                "socMin/socMax -- refusing to write a partial configuration"
+        async with self._write_lock:
+            config = await self.async_get_config()
+            if soc_min is None:
+                soc_min = config.get("socMin")
+            if soc_max is None:
+                soc_max = config.get("socMax")
+            if soc_min is None or soc_max is None:
+                raise EzhiCloudError(
+                    "cannot build a socLimit payload, the cloud config is missing "
+                    "socMin/socMax -- refusing to write a partial configuration"
+                )
+            soc_min = _to_int(soc_min, "socMin")
+            soc_max = _to_int(soc_max, "socMax")
+            _check_soc_window(soc_min, soc_max)
+            # Same rule as on the systemMode path. Raising socMin above
+            # dischargeProtection - 2 is refused here too, otherwise the shipped
+            # SOC Minimum entity would be a way around the guard.
+            _check_discharge_protection(config, requested)
+            data = await self._call(
+                "POST",
+                "remote/ezInverter/socLimit",
+                data={
+                    "deviceId": self._device_id,
+                    "type": "EZHI",
+                    "language": self._language,
+                    "socMin": str(soc_min),
+                    "socMax": str(soc_max),
+                },
             )
-        soc_min = _to_int(soc_min, "socMin")
-        soc_max = _to_int(soc_max, "socMax")
-        _check_soc_window(soc_min, soc_max)
-        # Same rule as on the systemMode path. Raising socMin above
-        # dischargeProtection - 2 is refused here too, otherwise the shipped
-        # SOC Minimum entity would be a way around the guard.
-        _check_discharge_protection(config, requested)
-        data = await self._call(
-            "POST",
-            "remote/ezInverter/socLimit",
-            data={
-                "deviceId": self._device_id,
-                "type": "EZHI",
-                "language": self._language,
-                "socMin": str(soc_min),
-                "socMax": str(soc_max),
-            },
-        )
         if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(
                 f"the inverter rejected socLimit {soc_min}..{soc_max}: {data}"

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -4,10 +4,10 @@ Control commands are cloud-only: the local HTTP API exposes five read endpoints
 plus setPower and nothing else. Verified exhaustively 2026-07-30/31.
 
 Endpoint paths and the systemMode field vocabulary come from the vendor
-app's own bundled API client, not from a packet capture: see
-docs/ezhi-cloud-api-from-app-source.md. Where that contradicts the older
-docs/ezhi-cloud-api-map.md, the app source wins -- the map's base URL was
-transcribed without the /api/v2 segment.
+app's own bundled API client, read out of the decompiled APK, not from a
+packet capture. Where a capture and the app source disagreed, the app source
+won -- an early transcription of the base URL dropped the /api/v2 segment,
+which every endpoint answers with a misleading "Internal Server Error".
 
 Deliberately free of homeassistant imports so it can be unit-tested standalone.
 """
@@ -92,8 +92,8 @@ SYSTEM_MODE_KEYS = ("systemMode", "EPS", "ECO", "userSetPower")
 # battery deep-discharge floor (live value seen: 12%), and a config lacking
 # any of these must not block a mode write.
 #
-# The full write vocabulary comes from the vendor app's own payload builders
-# (docs/ezhi-cloud-api-from-app-source.md). Deliberately NOT included:
+# The full write vocabulary comes from the vendor app's own payload builders.
+# Deliberately NOT included:
 # outputPowerStrategy and outputPowerStrategyWeekly. Those are lists, and
 # every value here goes through wire_str -- carrying a schedule forward as
 # str(list) would corrupt it.
@@ -192,12 +192,24 @@ def _as_int(value: Any) -> int | None:
         return None
 
 
+def _check_soc_window(soc_min: int, soc_max: int) -> None:
+    """Refuse an impossible SOC window. This writes real hardware config."""
+    if not 0 <= soc_min < soc_max <= 100:
+        raise EzhiCloudError(
+            f"refusing an implausible SOC window {soc_min}..{soc_max}"
+        )
+
+
 def _check_discharge_protection(config: dict, changes: dict) -> None:
     """Refuse a deep-discharge floor the device would silently clamp.
 
-    The vendor app enforces `dischargeProtection >= socMin + 2` and this write
-    path is the only other way in. Checked against the config that was just
-    re-read, so a socMin changed from the app a minute ago still counts.
+    The vendor app enforces `dischargeProtection >= socMin + 2`. Both write
+    paths that can move either value call this: async_set_system_mode and
+    async_set_soc_limit. It used to be only the first, and this docstring
+    claimed that was the only way in -- while the shipped SOC Minimum entity
+    went through the second and skipped the check entirely. Checked against
+    the config that was just re-read, so a socMin changed from the app a
+    minute ago still counts.
 
     Only checks when the caller is actually moving one of the two -- a mode
     switch that merely carries an already-out-of-range pair forward must not
@@ -794,18 +806,31 @@ class EzhiCloudApi:
     ) -> None:
         """Write the SOC bounds. The endpoint takes them as a pair.
 
-        Re-reads the current config to fill in whichever bound the caller left
-        out, rather than trusting a cached one: a poll can be up to a minute
-        old, and writing a stale bound back would undo a change made from the
-        vendor app in the meantime -- the same freshness rule async_set_system_
-        mode already applies to systemMode/EPS/ECO/userSetPower.
+        Re-reads the current config rather than trusting a cached one: a poll
+        can be up to a minute old, and writing a stale bound back would undo a
+        change made from the vendor app in the meantime -- the same freshness
+        rule async_set_system_mode already applies to systemMode/EPS/ECO/
+        userSetPower. The re-read is unconditional, because the discharge
+        protection check needs the current floor even when the caller supplied
+        both bounds.
         """
-        if soc_min is None or soc_max is None:
-            config = await self.async_get_config()
-            if soc_min is None:
-                soc_min = config.get("socMin")
-            if soc_max is None:
-                soc_max = config.get("socMax")
+        # What the caller is actually moving, as opposed to what the payload
+        # carries: this endpoint always sends both bounds, but a bound that is
+        # only being carried forward must not trip a guard it did not move.
+        requested = {
+            key: value
+            for key, value in (("socMin", soc_min), ("socMax", soc_max))
+            if value is not None
+        }
+        if soc_min is not None and soc_max is not None:
+            # The caller already gave us everything needed to judge the window,
+            # so an impossible one is refused without touching the network.
+            _check_soc_window(_to_int(soc_min, "socMin"), _to_int(soc_max, "socMax"))
+        config = await self.async_get_config()
+        if soc_min is None:
+            soc_min = config.get("socMin")
+        if soc_max is None:
+            soc_max = config.get("socMax")
         if soc_min is None or soc_max is None:
             raise EzhiCloudError(
                 "cannot build a socLimit payload, the cloud config is missing "
@@ -813,10 +838,11 @@ class EzhiCloudApi:
             )
         soc_min = _to_int(soc_min, "socMin")
         soc_max = _to_int(soc_max, "socMax")
-        if not 0 <= soc_min < soc_max <= 100:
-            raise EzhiCloudError(
-                f"refusing an implausible SOC window {soc_min}..{soc_max}"
-            )
+        _check_soc_window(soc_min, soc_max)
+        # Same rule as on the systemMode path. Raising socMin above
+        # dischargeProtection - 2 is refused here too, otherwise the shipped
+        # SOC Minimum entity would be a way around the guard.
+        _check_discharge_protection(config, requested)
         data = await self._call(
             "POST",
             "remote/ezInverter/socLimit",

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -308,6 +308,10 @@ class EzhiCloudApi:
 
     async def async_set_soc_limit(self, soc_min: int, soc_max: int) -> None:
         """Write both SOC bounds. The endpoint takes them as a pair."""
+        if not 0 <= soc_min < soc_max <= 100:
+            raise EzhiCloudError(
+                f"refusing an implausible SOC window {soc_min}..{soc_max}"
+            )
         data = await self._call(
             "POST",
             "remote/ezInverter/socLimit",

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -203,3 +203,64 @@ class EzhiCloudApi:
             params={"deviceId": self._device_id, "type": "EZHI",
                     "language": self._language},
         )
+
+    async def async_set_on_off(self, on: bool) -> None:
+        """Turn the inverter on or off.
+
+        The wire format is inverted: status=0 is ON, status=1 is OFF.
+
+        Turning ON only works while the inverter still answers over MQTT. Once it
+        is really powered down the cloud cannot wake it — that needs PV/DC input
+        or a 3 s press on the battery button. Verified 2026-07-31.
+        """
+        data = await self._call(
+            "POST",
+            f"remote/ezInverter/onOff/{self._device_id}",
+            data={"status": "0" if on else "1", "type": "EZHI",
+                  "language": self._language},
+        )
+        if not data.get("flag"):
+            raise EzhiCloudOfflineError(
+                f"the inverter rejected the on/off command (reason "
+                f"{data.get('reason')}) — it is powered down and the cloud "
+                "cannot wake it. Use PV/DC input or hold the battery button 3 s."
+            )
+
+    async def async_set_system_mode(self, config: dict, **changes: Any) -> None:
+        """Write systemMode, carrying every untouched field forward.
+
+        `config` must be a fresh async_get_config() payload.
+        """
+        params = build_system_mode_params(config, **changes)
+        data = await self._call(
+            "POST",
+            "remote/ezInverter/systemMode",
+            data={
+                "deviceId": self._device_id,
+                "type": "EZHI",
+                "identifierType": "1",
+                "maxPowerFlag": "0",
+                "language": self._language,
+                "params": json.dumps(params),
+            },
+        )
+        if not data.get("flag"):
+            raise EzhiCloudError(f"the inverter rejected systemMode={params}: {data}")
+
+    async def async_set_soc_limit(self, soc_min: int, soc_max: int) -> None:
+        """Write both SOC bounds. The endpoint takes them as a pair."""
+        data = await self._call(
+            "POST",
+            "remote/ezInverter/socLimit",
+            data={
+                "deviceId": self._device_id,
+                "type": "EZHI",
+                "language": self._language,
+                "socMin": str(int(soc_min)),
+                "socMax": str(int(soc_max)),
+            },
+        )
+        if not data.get("flag"):
+            raise EzhiCloudError(
+                f"the inverter rejected socLimit {soc_min}..{soc_max}: {data}"
+            )

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -172,11 +172,16 @@ class EzhiCloudApi:
         )
 
         code = body.get("code")
-        if status != 200 or code in AUTH_ERROR_CODES:
+        if status in (401, 403) or code in AUTH_ERROR_CODES:
             raise EzhiCloudAuthError(
                 f"refreshToken rejected (HTTP {status}, code {code}): the stored "
                 "refresh_token is no longer valid — capture a new one from the app"
             )
+        if status != 200:
+            # 5xx/429 means the cloud is unwell, not that our credentials are.
+            # Escalating here would stop HA polling and send the user on a
+            # pointless token re-capture that cannot fix anything.
+            raise EzhiCloudError(f"refreshToken -> HTTP {status}")
         if code != 0:
             raise EzhiCloudError(
                 f"refreshToken failed: code={code} msg={body.get('message')}"

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -288,11 +288,18 @@ class EzhiCloudApi:
                   "language": self._language},
         )
         if not data.get("flag"):
-            if on and data.get("reason") == 1:
+            if data.get("reason") == 1:
+                # reason:1 is an offline condition regardless of direction --
+                # only the concrete recovery advice is ON-specific.
+                if on:
+                    raise EzhiCloudOfflineError(
+                        f"the inverter rejected the on/off command (reason "
+                        f"{data.get('reason')}) — it is powered down and the cloud "
+                        "cannot wake it. Use PV/DC input or hold the battery button 3 s."
+                    )
                 raise EzhiCloudOfflineError(
-                    f"the inverter rejected the on/off command (reason "
-                    f"{data.get('reason')}) — it is powered down and the cloud "
-                    "cannot wake it. Use PV/DC input or hold the battery button 3 s."
+                    f"the inverter is not reachable by the cloud (reason 1); "
+                    f"the off command was not delivered: {data}"
                 )
             raise EzhiCloudError(
                 f"the inverter rejected the on/off command (on={on}): {data}"

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -108,28 +108,36 @@ class EzhiCloudApi:
         self._token_expires = 0.0  # forces a refresh on the first call
         self._lock = asyncio.Lock()
 
-    # --- token handling ---------------------------------------------------
+    # --- HTTP plumbing ------------------------------------------------------
 
-    async def _fetch_access_token(self) -> None:
-        """Exchange the refresh_token for a new access_token.
+    async def _http(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict | None = None,
+        data: dict | None = None,
+        headers: dict[str, str],
+    ) -> tuple[int, dict]:
+        """One HTTP round trip: timeout, transport-error wrapping, tolerant parse.
 
-        The refresh_token does not rotate, so it is never overwritten here.
+        Both the token endpoint and the API endpoints go through here. They
+        used to carry their own copies of this error handling, and a fix
+        applied to one copy but not the other cost us two separate bugs.
         """
         try:
             async with asyncio.timeout(self._timeout):
                 response = await self._session.request(
-                    "POST",
-                    TOKEN_URL,
-                    data={"refresh_token": self._refresh_token,
-                          "language": self._language},
-                    headers={"Authorization": f"Bearer {self._token}",
-                             "Accept-Language": self._language},
+                    method, url, params=params, data=data, headers=headers,
                 )
-                status = response.status
+                # A non-JSON body (e.g. an HTML error page from a
+                # gateway/WAF, common on 401/403/502) must not stop the
+                # caller from seeing the HTTP status.
                 try:
                     body = await response.json(content_type=None)
                 except ValueError:
                     body = {}
+                return response.status, body
         except EzhiCloudError:
             raise
         except (TypeError, AttributeError, NameError, KeyError, IndexError):
@@ -139,9 +147,29 @@ class EzhiCloudApi:
                 f"the EZHI cloud did not respond within {self._timeout}s: {err!r}"
             ) from err
         except Exception as err:
+            # Everything else coming out of session.request/response.json is
+            # a transport failure by definition -- we cannot import aiohttp
+            # here to catch its ClientError family by name, so this catches
+            # broadly and re-wraps.
             raise EzhiCloudError(
                 f"transport failure talking to the EZHI cloud: {err!r}"
             ) from err
+
+    # --- token handling ---------------------------------------------------
+
+    async def _fetch_access_token(self) -> None:
+        """Exchange the refresh_token for a new access_token.
+
+        The refresh_token does not rotate, so it is never overwritten here.
+        """
+        status, body = await self._http(
+            "POST",
+            TOKEN_URL,
+            data={"refresh_token": self._refresh_token,
+                  "language": self._language},
+            headers={"Authorization": f"Bearer {self._token}",
+                     "Accept-Language": self._language},
+        )
 
         code = body.get("code")
         if status != 200 or code in AUTH_ERROR_CODES:
@@ -177,46 +205,20 @@ class EzhiCloudApi:
         self, method: str, path: str, params: dict | None, data: dict | None,
         token: str,
     ) -> tuple[int, dict]:
-        url = f"{API_URL}/{path.lstrip('/')}"
         # Takes the bearer token as an explicit parameter rather than reading
         # self._token: the caller (_call) decides which token a given attempt
         # uses. That keeps the "first attempt uses the pre-refresh token,
         # the retry uses the fresh one" invariant structural instead of
         # relying on nothing suspending between the two reads of self._token.
-        #
-        # Everything coming out of session.request/response.json below is a
-        # transport failure by definition -- we cannot import aiohttp here to
-        # catch its ClientError family by name, so this catches broadly and
-        # re-wraps. EzhiCloudError itself is deliberately passed through
-        # unchanged (nothing inside this block raises one today, but the
-        # guard keeps a future change from getting double-wrapped).
-        try:
-            async with asyncio.timeout(self._timeout):
-                response = await self._session.request(
-                    method,
-                    url,
-                    params=params,
-                    data=data,
-                    headers={"Authorization": f"Bearer {token}",
-                             "Accept-Language": self._language},
-                )
-                try:
-                    body = await response.json(content_type=None)
-                except ValueError:
-                    body = {}
-                return response.status, body
-        except EzhiCloudError:
-            raise
-        except (TypeError, AttributeError, NameError, KeyError, IndexError):
-            raise                      # our bug, not the network's
-        except TimeoutError as err:
-            raise EzhiCloudError(
-                f"the EZHI cloud did not respond within {self._timeout}s: {err!r}"
-            ) from err
-        except Exception as err:
-            raise EzhiCloudError(
-                f"transport failure talking to the EZHI cloud: {err!r}"
-            ) from err
+        url = f"{API_URL}/{path.lstrip('/')}"
+        return await self._http(
+            method,
+            url,
+            params=params,
+            data=data,
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept-Language": self._language},
+        )
 
     async def _call(
         self,

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -164,13 +164,28 @@ class EzhiCloudApi:
         data: dict | None = None,
     ) -> dict:
         """One authenticated call. A 401 buys exactly one refresh + retry."""
+        # ponytail: worst case here is ~4x self._timeout (ensure_token, first
+        # send, ensure_token again, retry send) with no wrapping deadline.
+        # HA's DataUpdateCoordinator won't start an overlapping refresh, so
+        # this can't compound -- add a wrapping deadline only if it ever does.
         await self._ensure_token()
+        token_used = self._token
         status, body = await self._raw(method, path, params, data)
 
         if status == 401:
-            self._token_expires = 0.0
+            async with self._lock:
+                # Only invalidate if nobody else refreshed while we waited --
+                # otherwise a concurrent caller's fresh token gets discarded.
+                if self._token == token_used:
+                    self._token_expires = 0.0
             await self._ensure_token()
             status, body = await self._raw(method, path, params, data)
+
+        if status == 401:
+            raise EzhiCloudAuthError(
+                f"{method} {path} -> HTTP 401 even with a freshly refreshed "
+                "token; the stored credentials are no longer accepted"
+            )
 
         if status != 200:
             raise EzhiCloudError(f"{method} {path} -> HTTP {status}")

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -272,10 +272,14 @@ class EzhiCloudApi:
                   "language": self._language},
         )
         if not data.get("flag"):
-            raise EzhiCloudOfflineError(
-                f"the inverter rejected the on/off command (reason "
-                f"{data.get('reason')}) — it is powered down and the cloud "
-                "cannot wake it. Use PV/DC input or hold the battery button 3 s."
+            if on and data.get("reason") == 1:
+                raise EzhiCloudOfflineError(
+                    f"the inverter rejected the on/off command (reason "
+                    f"{data.get('reason')}) — it is powered down and the cloud "
+                    "cannot wake it. Use PV/DC input or hold the battery button 3 s."
+                )
+            raise EzhiCloudError(
+                f"the inverter rejected the on/off command (on={on}): {data}"
             )
 
     async def async_set_system_mode(self, config: dict, **changes: Any) -> None:

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -47,18 +47,33 @@ class EzhiCloudOfflineError(EzhiCloudError):
 SYSTEM_MODE_KEYS = ("systemMode", "EPS", "ECO", "userSetPower")
 
 
+def _wire_str(value: Any) -> str:
+    """Format a value the way the cloud expects it: "1"/"0", never "True"."""
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
 def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     """Read-modify-write: carry the current config forward, override `changes`.
 
     `config` is the payload of a systemMode GET. Raises rather than defaulting a
-    missing field — a wrong guess here would reconfigure real hardware.
+    missing field — a wrong guess here would reconfigure real hardware. Also
+    raises on an unknown field name in `changes`, e.g. a typo, which would
+    otherwise sail through as a silent no-op.
     """
+    unknown = set(changes) - set(SYSTEM_MODE_KEYS)
+    if unknown:
+        raise EzhiCloudError(f"unknown systemMode field(s) {sorted(unknown)}")
+
     params = {
-        key: str(config[key])
+        key: _wire_str(config[key])
         for key in SYSTEM_MODE_KEYS
         if config.get(key) is not None
     }
-    params.update({key: str(value) for key, value in changes.items()})
+    params.update({key: _wire_str(value) for key, value in changes.items()})
 
     missing = [key for key in SYSTEM_MODE_KEYS if key not in params]
     if missing:

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -545,10 +545,11 @@ class EzhiCloudApi:
         in a state the device rejects or silently corrects. Disabling backup
         does NOT set ECO -- off is off, not "switch to the other one".
 
-        Note the vendor app only exposes this in modes 1, 2 and 5; in Local
-        mode (4) it shows no backup switch, though the field keeps its value.
-        Whether a write lands there is unverified, so nothing here pretends it
-        did: the caller's post-write re-read is the only confirmation.
+        The vendor app only exposes this in modes 1, 2 and 5, but the write
+        does land in Local mode (4) too: measured 2026-08-01, EPS went 1 -> 0
+        -> 1 from Home Assistant while the device stayed in mode 4, with no
+        change to any other config field. The app hiding the switch is a UI
+        decision, not an API restriction.
         """
         changes = {"EPS": "1", "ECO": "0"} if on else {"EPS": "0"}
         await self.async_set_system_mode(**changes)

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -57,6 +57,20 @@ def _wire_str(value: Any) -> str:
     return str(value)
 
 
+def _is_truthy(value: Any) -> bool:
+    """Accept a JSON bool or its string spelling: the cloud sends both.
+
+    Write responses are unverified by the Task 5 live probe (it only checks
+    the GET), and every field of the GET payload turned out to be a string --
+    that is precisely why _wire_str exists. bool("false") is True in plain
+    Python, so a naive truthy check would silently count a rejected write as
+    a success.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "0", "false", "null")
+    return bool(value)
+
+
 def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     """Read-modify-write: carry the current config forward, override `changes`.
 
@@ -144,15 +158,18 @@ class EzhiCloudApi:
             raise                      # our bug, not the network's
         except TimeoutError as err:
             raise EzhiCloudError(
-                f"the EZHI cloud did not respond within {self._timeout}s: {err!r}"
+                f"the EZHI cloud did not respond within {self._timeout}s "
+                f"({method} {url}): {err!r}"
             ) from err
         except Exception as err:
             # Everything else coming out of session.request/response.json is
             # a transport failure by definition -- we cannot import aiohttp
             # here to catch its ClientError family by name, so this catches
-            # broadly and re-wraps.
+            # broadly and re-wraps. The URL is included so a token-endpoint
+            # failure and an API-endpoint failure don't read identically in
+            # the HA log.
             raise EzhiCloudError(
-                f"transport failure talking to the EZHI cloud: {err!r}"
+                f"transport failure talking to the EZHI cloud ({method} {url}): {err!r}"
             ) from err
 
     # --- token handling ---------------------------------------------------
@@ -312,8 +329,8 @@ class EzhiCloudApi:
             data={"status": "0" if on else "1", "type": "EZHI",
                   "language": self._language},
         )
-        if not data.get("flag"):
-            if data.get("reason") == 1:
+        if not _is_truthy(data.get("flag")):
+            if str(data.get("reason")) == "1":
                 # reason:1 is an offline condition regardless of direction --
                 # only the concrete recovery advice is ON-specific.
                 if on:
@@ -351,7 +368,7 @@ class EzhiCloudApi:
                 "params": json.dumps(params),
             },
         )
-        if not data.get("flag"):
+        if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(f"the inverter rejected systemMode={params}: {data}")
 
     async def async_set_soc_limit(self, soc_min: int, soc_max: int) -> None:
@@ -371,7 +388,7 @@ class EzhiCloudApi:
                 "socMax": str(int(soc_max)),
             },
         )
-        if not data.get("flag"):
+        if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(
                 f"the inverter rejected socLimit {soc_min}..{soc_max}: {data}"
             )

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -71,6 +71,39 @@ def _is_truthy(value: Any) -> bool:
     return bool(value)
 
 
+def _to_int(value: Any, field: str) -> int:
+    """Parse a cloud-config field to int.
+
+    Wraps a malformed value in EzhiCloudError instead of letting a bare
+    ValueError escape: this runs on data read back from the cloud (untrusted),
+    not on a value we constructed ourselves, so it belongs with the other
+    "the cloud sent something we didn't expect" cases, not the programming-
+    error list _http() deliberately leaves unwrapped.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError) as err:
+        raise EzhiCloudError(
+            f"cloud config field {field!r} is not numeric: {value!r}"
+        ) from err
+
+
+def is_running(on_off_value: Any) -> bool | None:
+    """Read the inverted onOff field: "0" means the inverter is running.
+
+    Tolerates the spellings the cloud might use for the same value -- the
+    payload types are not verified until the live probe runs, and
+    tests/test_cloud.py already disagrees with itself about whether socMin
+    (a sibling field of the same GET payload) is a string or an int. Routed
+    through _wire_str rather than a bare `str(...) == "0"` comparison so a
+    bool or float value normalises the same way async_set_on_off's own
+    request body does.
+    """
+    if on_off_value is None:
+        return None
+    return _wire_str(on_off_value) == "0"
+
+
 def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     """Read-modify-write: carry the current config forward, override `changes`.
 
@@ -371,8 +404,30 @@ class EzhiCloudApi:
         if not _is_truthy(data.get("flag")):
             raise EzhiCloudError(f"the inverter rejected systemMode={params}: {data}")
 
-    async def async_set_soc_limit(self, soc_min: int, soc_max: int) -> None:
-        """Write both SOC bounds. The endpoint takes them as a pair."""
+    async def async_set_soc_limit(
+        self, soc_min: int | None = None, soc_max: int | None = None
+    ) -> None:
+        """Write the SOC bounds. The endpoint takes them as a pair.
+
+        Re-reads the current config to fill in whichever bound the caller left
+        out, rather than trusting a cached one: a poll can be up to a minute
+        old, and writing a stale bound back would undo a change made from the
+        vendor app in the meantime -- the same freshness rule async_set_system_
+        mode already applies to systemMode/EPS/ECO/userSetPower.
+        """
+        if soc_min is None or soc_max is None:
+            config = await self.async_get_config()
+            if soc_min is None:
+                soc_min = config.get("socMin")
+            if soc_max is None:
+                soc_max = config.get("socMax")
+        if soc_min is None or soc_max is None:
+            raise EzhiCloudError(
+                "cannot build a socLimit payload, the cloud config is missing "
+                "socMin/socMax -- refusing to write a partial configuration"
+            )
+        soc_min = _to_int(soc_min, "socMin")
+        soc_max = _to_int(soc_max, "socMax")
         if not 0 <= soc_min < soc_max <= 100:
             raise EzhiCloudError(
                 f"refusing an implausible SOC window {soc_min}..{soc_max}"
@@ -384,8 +439,8 @@ class EzhiCloudApi:
                 "deviceId": self._device_id,
                 "type": "EZHI",
                 "language": self._language,
-                "socMin": str(int(soc_min)),
-                "socMax": str(int(soc_max)),
+                "socMin": str(soc_min),
+                "socMax": str(soc_max),
             },
         )
         if not _is_truthy(data.get("flag")):

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -17,7 +17,14 @@ from typing import Any
 _LOGGER = logging.getLogger(__name__)
 
 BASE_URL = "https://app.api.apsystemsema.com:9223"
-API_URL = f"{BASE_URL}/aps-api-web"
+# The /api/v2 segment is mandatory and measured, not inferred: without it every
+# remote/ezInverter endpoint answers HTTP 200 with body code 4 "Internal Server
+# Error" -- which reads like a cloud outage, not a wrong path. Probed 2026-08-01
+# across six read endpoints, all six code 4 -> code 0 with the segment. The
+# reference doc contradicted itself here; test_api_url_carries_the_v2_segment
+# pins it so a future edit cannot quietly drop it again.
+API_URL = f"{BASE_URL}/aps-api-web/api/v2"
+# The token endpoint is NOT under /aps-api-web and NOT versioned. Verified live.
 TOKEN_URL = f"{BASE_URL}/api/token/refreshToken"
 
 # The JWT lives 2 h. Refresh well before that rather than waiting for a 401 —

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -174,9 +174,16 @@ class EzhiCloudApi:
     # --- request plumbing -------------------------------------------------
 
     async def _send_once(
-        self, method: str, path: str, params: dict | None, data: dict | None
+        self, method: str, path: str, params: dict | None, data: dict | None,
+        token: str,
     ) -> tuple[int, dict]:
         url = f"{API_URL}/{path.lstrip('/')}"
+        # Takes the bearer token as an explicit parameter rather than reading
+        # self._token: the caller (_call) decides which token a given attempt
+        # uses. That keeps the "first attempt uses the pre-refresh token,
+        # the retry uses the fresh one" invariant structural instead of
+        # relying on nothing suspending between the two reads of self._token.
+        #
         # Everything coming out of session.request/response.json below is a
         # transport failure by definition -- we cannot import aiohttp here to
         # catch its ClientError family by name, so this catches broadly and
@@ -190,7 +197,7 @@ class EzhiCloudApi:
                     url,
                     params=params,
                     data=data,
-                    headers={"Authorization": f"Bearer {self._token}",
+                    headers={"Authorization": f"Bearer {token}",
                              "Accept-Language": self._language},
                 )
                 try:
@@ -225,7 +232,7 @@ class EzhiCloudApi:
         # this can't compound -- add a wrapping deadline only if it ever does.
         await self._ensure_token()
         token_used = self._token
-        status, body = await self._send_once(method, path, params, data)
+        status, body = await self._send_once(method, path, params, data, token_used)
 
         if status == 401:
             # ponytail: this capture-then-invalidate dance is untested -- no
@@ -240,7 +247,10 @@ class EzhiCloudApi:
                 if self._token == token_used:
                     self._token_expires = 0.0
             await self._ensure_token()
-            status, body = await self._send_once(method, path, params, data)
+            # The retry must use the freshly refreshed token, not the one
+            # captured above -- reusing token_used here would defeat the
+            # refresh that was just forced.
+            status, body = await self._send_once(method, path, params, data, self._token)
 
         if status == 401:
             raise EzhiCloudAuthError(

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -282,11 +282,14 @@ class EzhiCloudApi:
                 f"the inverter rejected the on/off command (on={on}): {data}"
             )
 
-    async def async_set_system_mode(self, config: dict, **changes: Any) -> None:
+    async def async_set_system_mode(self, **changes: Any) -> None:
         """Write systemMode, carrying every untouched field forward.
 
-        `config` must be a fresh async_get_config() payload.
+        Reads the current config first rather than trusting a cached one: a
+        poll can be up to a minute old, and writing a stale EPS/ECO back would
+        undo a change made from the vendor app in the meantime.
         """
+        config = await self.async_get_config()
         params = build_system_mode_params(config, **changes)
         data = await self._call(
             "POST",

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -43,13 +43,31 @@ class EzhiCloudOfflineError(EzhiCloudError):
     """The inverter is not reachable by the cloud (MQTT disconnected)."""
 
 
-# The systemMode POST replaces the whole params blob. Anything left out risks
-# being defaulted away by the cloud — so every field we know about travels along.
+# Whether the systemMode POST merges into the cloud's existing params or
+# replaces the whole blob is unresolved. The evidence points at merge -- the
+# captured app payload for "back to Local" was just {"systemMode":"4",
+# "stayOn":"0"} and a config-GET right after still showed EPS:1 (backup
+# stayed enabled) -- but nothing here rules out replace. Carrying every
+# field we know about is harmless if it merges and essential if it
+# replaces, so both branches below do it either way.
+#
+# Required: a config that doesn't have these yet is refused rather than
+# guessed at, since a wrong guess drives real hardware and all four always
+# exist once the cloud has answered even once.
 SYSTEM_MODE_KEYS = ("systemMode", "EPS", "ECO", "userSetPower")
+# Carried forward when present, never required: dischargeProtection is a real
+# battery deep-discharge floor (live value seen: 12%), and a config lacking
+# any of these four must not block a mode write.
+SYSTEM_MODE_OPTIONAL_KEYS = ("dischargeProtection", "stayOn", "governmentLevies", "area")
 
 
-def _wire_str(value: Any) -> str:
-    """Format a value the way the cloud expects it: "1"/"0", never "True"."""
+def wire_str(value: Any) -> str:
+    """Format a value the way the cloud expects it: "1"/"0", never "True".
+
+    Public (no leading underscore): select.py's current_option reads the same
+    systemMode payload this normalises for writes, and needs to agree with it
+    -- a raw `str(2.0)` gives "2.0", not the "2" this produces.
+    """
     if isinstance(value, bool):
         return "1" if value else "0"
     if isinstance(value, float) and value.is_integer():
@@ -62,7 +80,7 @@ def _is_truthy(value: Any) -> bool:
 
     Write responses are unverified by the Task 5 live probe (it only checks
     the GET), and every field of the GET payload turned out to be a string --
-    that is precisely why _wire_str exists. bool("false") is True in plain
+    that is precisely why wire_str exists. bool("false") is True in plain
     Python, so a naive truthy check would silently count a rejected write as
     a success.
     """
@@ -74,6 +92,12 @@ def _is_truthy(value: Any) -> bool:
 def _to_int(value: Any, field: str) -> int:
     """Parse a cloud-config field to int.
 
+    int(float(value)), not int(value): the read side (number.py's
+    _safe_float) is fine with a value like "100.0", and the write side must
+    accept exactly what the read side just displayed -- otherwise editing one
+    SOC bound legitimately fails because the *other*, untouched bound came
+    back from the cloud as "100.0" and int() alone rejects it outright.
+
     Wraps a malformed value in EzhiCloudError instead of letting a bare
     ValueError escape: this runs on data read back from the cloud (untrusted),
     not on a value we constructed ourselves, so it belongs with the other
@@ -81,7 +105,7 @@ def _to_int(value: Any, field: str) -> int:
     error list _http() deliberately leaves unwrapped.
     """
     try:
-        return int(value)
+        return int(float(value))
     except (TypeError, ValueError) as err:
         raise EzhiCloudError(
             f"cloud config field {field!r} is not numeric: {value!r}"
@@ -95,33 +119,56 @@ def is_running(on_off_value: Any) -> bool | None:
     payload types are not verified until the live probe runs, and
     tests/test_cloud.py already disagrees with itself about whether socMin
     (a sibling field of the same GET payload) is a string or an int. Routed
-    through _wire_str rather than a bare `str(...) == "0"` comparison so a
+    through wire_str rather than a bare `str(...) == "0"` comparison so a
     bool or float value normalises the same way async_set_on_off's own
     request body does.
+
+    Returns None -- not a guess -- for a value that normalises to neither "0"
+    nor "1". A default of False here would report "off" with full confidence
+    while the inverter might be running, and an is_state(..., 'off') ->
+    turn_on automation would then fire a hardware write on bad information.
+    select.py's current_option and number.py's _safe_float already refuse to
+    guess the same way for their own unmapped/unparsable values.
     """
     if on_off_value is None:
         return None
-    return _wire_str(on_off_value) == "0"
+    wire = wire_str(on_off_value)
+    if wire == "0":
+        return True
+    if wire == "1":
+        return False
+    return None
 
 
 def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     """Read-modify-write: carry the current config forward, override `changes`.
 
     `config` is the payload of a systemMode GET. Raises rather than defaulting a
-    missing field — a wrong guess here would reconfigure real hardware. Also
-    raises on an unknown field name in `changes`, e.g. a typo, which would
-    otherwise sail through as a silent no-op.
+    required field that's missing — a wrong guess here would reconfigure real
+    hardware. Also raises on an unknown field name in `changes`, e.g. a typo,
+    which would otherwise sail through as a silent no-op.
+
+    The four SYSTEM_MODE_OPTIONAL_KEYS travel along too when the config has
+    them, but their absence is never an error: see the module comment above
+    SYSTEM_MODE_KEYS for why both required-and-strict and optional-and-best-
+    effort are correct for the same unresolved merge-vs-replace question.
     """
-    unknown = set(changes) - set(SYSTEM_MODE_KEYS)
+    known_fields = set(SYSTEM_MODE_KEYS) | set(SYSTEM_MODE_OPTIONAL_KEYS)
+    unknown = set(changes) - known_fields
     if unknown:
         raise EzhiCloudError(f"unknown systemMode field(s) {sorted(unknown)}")
 
     params = {
-        key: _wire_str(config[key])
+        key: wire_str(config[key])
         for key in SYSTEM_MODE_KEYS
         if config.get(key) is not None
     }
-    params.update({key: _wire_str(value) for key, value in changes.items()})
+    params.update({
+        key: wire_str(config[key])
+        for key in SYSTEM_MODE_OPTIONAL_KEYS
+        if config.get(key) is not None
+    })
+    params.update({key: wire_str(value) for key, value in changes.items()})
 
     missing = [key for key in SYSTEM_MODE_KEYS if key not in params]
     if missing:
@@ -363,7 +410,12 @@ class EzhiCloudApi:
                   "language": self._language},
         )
         if not _is_truthy(data.get("flag")):
-            if str(data.get("reason")) == "1":
+            # wire_str, not a bare str(): reason=1.0 or reason=True must land
+            # on the offline branch too, the same normalisation is_running
+            # was moved onto for the same reason -- a bare comparison here
+            # would silently fall through to the generic error and the user
+            # loses the battery-button recovery instructions.
+            if wire_str(data.get("reason")) == "1":
                 # reason:1 is an offline condition regardless of direction --
                 # only the concrete recovery advice is ON-specific.
                 if on:

--- a/custom_components/apsystems_ezhi_local/cloud.py
+++ b/custom_components/apsystems_ezhi_local/cloud.py
@@ -31,6 +31,23 @@ BASE_URL = "https://app.api.apsystemsema.com:9223"
 API_URL = f"{BASE_URL}/aps-api-web/api/v2"
 # The token endpoint is NOT under /aps-api-web and NOT versioned. Verified live.
 TOKEN_URL = f"{BASE_URL}/api/token/refreshToken"
+LOGIN_URL = f"{BASE_URL}/api/token/generateToken/user/loginEncrypt"
+
+# Login credentials from the vendor app, recovered from the decompiled APK
+# (S0/c.java, called from com/apsystems/apeasypower/http/d.java). They are
+# constants of the app, identical for every user, and trivially extractable
+# from the APK by anyone -- but see the README: shipping them is what removes
+# the HTTPS-proxy capture from the setup instructions.
+LOGIN_APP_ID = "4029817264d4821d0164d4821dd80015"
+LOGIN_APP_SECRET = "EZAd2023"
+# RSA-2048 public key the app wraps the per-login AES key and IV in.
+LOGIN_PUBLIC_KEY_DER_B64 = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgdwBhVodMQ84lYZhDSGOUDQAks+NMa7WQ83mR1OyHiIW"
+    "tZ1wWAh4H7fclkdNS3lWCmDH9ldF7Kf6JlEvZTc0Textv+YMLXO2gdDIoBvg7vlhY4HxOjXUIFQ+s7cWRrmEIgVV"
+    "nTBLZU1GMC8zld7WH9v9EYCAqK7rvGJP0STZ/g6BP8RGJKhdpY6b+ndMXRUBYwkqy8m1SDJHm1FeHSLQWTaWbP5p"
+    "z1yrGkkwvx+pib6wli+WE70/uPHp0zXZK5iUwmRQfOkTjDOGJyEE1dqkfHDTqne5ED81M4fCIEFYhyvnr1rifVJK"
+    "HCDRGYQpJ0CiffjjH1ZOGSIN4JPG1EEIjQIDAQAB"
+)
 
 # The JWT lives 2 h. Refresh well before that rather than waiting for a 401 —
 # the 401 path stays as the backstop. This is our refresh cadence, not the
@@ -320,6 +337,169 @@ def build_system_mode_params(config: dict, **changes: Any) -> dict[str, str]:
     return params
 
 
+async def _http_request(
+    session: Any,
+    timeout: int,
+    method: str,
+    url: str,
+    *,
+    params: dict | None = None,
+    data: dict | None = None,
+    headers: dict[str, str],
+) -> tuple[int, dict]:
+    """One HTTP round trip: timeout, transport-error wrapping, tolerant parse.
+
+    The token endpoint, the API endpoints and the login all go through here.
+    They used to carry their own copies of this error handling, and a fix
+    applied to one copy but not the other cost us two separate bugs. Module
+    level rather than a method because login runs before there is a client.
+    """
+    try:
+        async with asyncio.timeout(timeout):
+            response = await session.request(
+                method, url, params=params, data=data, headers=headers,
+            )
+            # A non-JSON body (e.g. an HTML error page from a gateway/WAF,
+            # common on 401/403/502) must not stop the caller from seeing
+            # the HTTP status.
+            try:
+                body = await response.json(content_type=None)
+            except ValueError:
+                body = {}
+            return response.status, body
+    except EzhiCloudError:
+        raise
+    except (TypeError, AttributeError, NameError, KeyError, IndexError):
+        raise                      # our bug, not the network's
+    except TimeoutError as err:
+        raise EzhiCloudError(
+            f"the EZHI cloud did not respond within {timeout}s "
+            f"({method} {url}): {err!r}"
+        ) from err
+    except Exception as err:
+        # Everything else coming out of session.request/response.json is a
+        # transport failure by definition -- we cannot import aiohttp here to
+        # catch its ClientError family by name, so this catches broadly and
+        # re-wraps. The URL is included so a token-endpoint failure and an
+        # API-endpoint failure don't read identically in the HA log.
+        raise EzhiCloudError(
+            f"transport failure talking to the EZHI cloud ({method} {url}): {err!r}"
+        ) from err
+
+
+# --- login ------------------------------------------------------------------
+#
+# The app does not send the password in the clear. Per login it draws a random
+# AES-256 key and IV, RSA-wraps both under a public key baked into the APK, and
+# sends the credentials AES-CBC encrypted. Reproduced from S0/c.java; the odd
+# parts are faithful to the app and not cleanups waiting to happen:
+#
+#   * the AES key is the *hex text* of 16 random bytes (32 chars -> AES-256),
+#     not the bytes themselves; the IV is a 16-digit decimal string
+#   * padding is manual zero-fill, and on an exact block multiple the app adds
+#     a whole extra block of zeros. PKCS7 here would be rejected.
+#
+# A wrong reproduction of either fails as "wrong password", so both are pinned
+# by tests against fixed key/IV vectors.
+
+
+def _aes_hex(plain: str, key: str, iv: str) -> str:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    raw = plain.encode()
+    raw += b"\0" * (16 - len(raw) % 16)
+    encryptor = Cipher(algorithms.AES(key.encode()), modes.CBC(iv.encode())).encryptor()
+    return (encryptor.update(raw) + encryptor.finalize()).hex()
+
+
+def _rsa_b64(text: str) -> str:
+    import base64
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    public_key = serialization.load_der_public_key(
+        base64.b64decode(LOGIN_PUBLIC_KEY_DER_B64)
+    )
+    return base64.b64encode(
+        public_key.encrypt(text.encode(), padding.PKCS1v15())
+    ).decode()
+
+
+def build_login_params(
+    username: str, password: str, *, key: str | None = None, iv: str | None = None,
+) -> dict[str, str]:
+    """The form body for loginEncrypt.
+
+    key/iv are injectable so the crypto can be tested against fixed vectors;
+    production always draws them fresh.
+    """
+    import os
+    import secrets
+
+    if key is None:
+        key = os.urandom(16).hex()                       # 32 chars -> AES-256
+    if iv is None:
+        iv = f"{secrets.randbelow(10 ** 16):016d}"       # 16 chars -> CBC IV
+    return {
+        "app_id": LOGIN_APP_ID,
+        "app_secret": LOGIN_APP_SECRET,
+        "key": _rsa_b64(key),
+        "version": _rsa_b64(iv),
+        "username": _aes_hex(username, key, iv),
+        "password": _aes_hex(password, key, iv),
+    }
+
+
+async def async_login(
+    session: Any,
+    username: str,
+    password: str,
+    language: str = "en",
+    timeout: int = 15,
+) -> dict[str, str]:
+    """Trade EMA account credentials for a token pair.
+
+    Returns ``{"access_token": ..., "refresh_token": ...}``. The refresh_token
+    does not rotate, so this only has to succeed once -- but doing it here
+    rather than telling the user to run an HTTPS proxy is the difference
+    between a setup a person can complete and one they cannot.
+
+    The password is used to build the request and is never stored or logged.
+    """
+    status, body = await _http_request(
+        session,
+        timeout,
+        "POST",
+        LOGIN_URL,
+        data={**build_login_params(username, password), "language": language},
+        headers={"Accept-Language": language},
+    )
+
+    if status != 200:
+        # 5xx/429 is the cloud being unwell, not a bad password. Saying
+        # "wrong credentials" here would send the user to change a password
+        # that was fine.
+        raise EzhiCloudError(f"loginEncrypt -> HTTP {status}")
+
+    code = body.get("code")
+    if code != 0:
+        raise EzhiCloudAuthError(
+            f"login rejected by the EZHI cloud (code={code}): "
+            f"{body.get('message') or 'check the email address and password'}"
+        )
+
+    data = body.get("data") or {}
+    access_token = data.get("access_token")
+    refresh_token = data.get("refresh_token")
+    if not access_token or not refresh_token:
+        raise EzhiCloudAuthError(
+            "login succeeded but the response carried no token pair"
+        )
+    _LOGGER.debug("EZHI cloud: login succeeded, token pair obtained")
+    return {"access_token": access_token, "refresh_token": refresh_token}
+
+
 class EzhiCloudApi:
     """Authenticated client for the EMA cloud control endpoints."""
 
@@ -354,44 +534,10 @@ class EzhiCloudApi:
         data: dict | None = None,
         headers: dict[str, str],
     ) -> tuple[int, dict]:
-        """One HTTP round trip: timeout, transport-error wrapping, tolerant parse.
-
-        Both the token endpoint and the API endpoints go through here. They
-        used to carry their own copies of this error handling, and a fix
-        applied to one copy but not the other cost us two separate bugs.
-        """
-        try:
-            async with asyncio.timeout(self._timeout):
-                response = await self._session.request(
-                    method, url, params=params, data=data, headers=headers,
-                )
-                # A non-JSON body (e.g. an HTML error page from a
-                # gateway/WAF, common on 401/403/502) must not stop the
-                # caller from seeing the HTTP status.
-                try:
-                    body = await response.json(content_type=None)
-                except ValueError:
-                    body = {}
-                return response.status, body
-        except EzhiCloudError:
-            raise
-        except (TypeError, AttributeError, NameError, KeyError, IndexError):
-            raise                      # our bug, not the network's
-        except TimeoutError as err:
-            raise EzhiCloudError(
-                f"the EZHI cloud did not respond within {self._timeout}s "
-                f"({method} {url}): {err!r}"
-            ) from err
-        except Exception as err:
-            # Everything else coming out of session.request/response.json is
-            # a transport failure by definition -- we cannot import aiohttp
-            # here to catch its ClientError family by name, so this catches
-            # broadly and re-wraps. The URL is included so a token-endpoint
-            # failure and an API-endpoint failure don't read identically in
-            # the HA log.
-            raise EzhiCloudError(
-                f"transport failure talking to the EZHI cloud ({method} {url}): {err!r}"
-            ) from err
+        return await _http_request(
+            self._session, self._timeout, method, url,
+            params=params, data=data, headers=headers,
+        )
 
     # --- token handling ---------------------------------------------------
 

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -114,7 +114,10 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Cheap: the deviceId is already cached, so this costs one
                 # extra cloud call instead of leaving the user staring at
                 # "Cloud credentials updated" right before the same reauth
-                # dialog reopens on the next failed poll.
+                # dialog reopens on the next failed poll. This also happens
+                # to exercise the refresh_token specifically -- __init__
+                # forces _token_expires = 0.0, so the first call always goes
+                # through _fetch_access_token first.
                 api = EzhiCloudApi(
                     session=async_get_clientsession(self.hass),
                     device_id=device_id,
@@ -122,12 +125,19 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     refresh_token=user_input[CONF_CLOUD_REFRESH_TOKEN],
                 )
                 try:
-                    await api.async_get_config()
+                    # A caller sitting in front of a modal dialog is exactly
+                    # the "overlapping refresh" case cloud.py's _call() opts
+                    # out of a wrapping deadline for -- so this one supplies
+                    # its own rather than risking ~4x15s on a hung cloud.
+                    async with asyncio.timeout(20):
+                        await api.async_get_config()
                 except EzhiCloudAuthError:
                     _errors["base"] = "cloud_auth_failed"
-                except EzhiCloudError as err:
-                    # A transport hiccup or a cloud outage must not stop the
-                    # user from fixing their credentials.
+                except (EzhiCloudError, TimeoutError) as err:
+                    # A transport hiccup, a cloud outage or our own timeout
+                    # must not stop the user from fixing their credentials --
+                    # and must not stop someone whose inverter is simply
+                    # switched off (EzhiCloudOfflineError) from doing so either.
                     LOGGER.warning(
                         "Could not verify the new cloud credentials: %s", err
                     )
@@ -143,20 +153,25 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_CLOUD_ACCESS_TOKEN): vol.All(
+                    TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                    vol.Length(min=1),
+                ),
+                vol.Required(CONF_CLOUD_REFRESH_TOKEN): vol.All(
+                    TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                    vol.Length(min=1),
+                ),
+            }
+        )
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): vol.All(
-                        TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
-                        vol.Length(min=1),
-                    ),
-                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): vol.All(
-                        TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
-                        vol.Length(min=1),
-                    ),
-                }
-            ),
+            # None on the first call (no user_input yet); add_suggested_values_
+            # to_schema handles that by leaving the schema untouched. On a
+            # cloud_auth_failed re-show it re-populates both fields so a typo
+            # doesn't mean pasting a long token pair a second time.
+            data_schema=self.add_suggested_values_to_schema(schema, user_input),
             errors=_errors,
         )
 

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -17,6 +17,10 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_OUTPUT,
     DEFAULT_SCAN_INTERVAL_ALARM,
     UPDATE_INTERVAL,
+    CONF_CLOUD_ACCESS_TOKEN,
+    CONF_CLOUD_REFRESH_TOKEN,
+    CONF_CLOUD_SCAN_INTERVAL,
+    DEFAULT_CLOUD_SCAN_INTERVAL,
 )
 from .api import APsystemsEZHI
 
@@ -62,9 +66,50 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional("check", default=True): bool,
                     vol.Optional(SCAN_INTERVAL_OUTPUT, default=DEFAULT_SCAN_INTERVAL_OUTPUT): int,
                     vol.Optional(SCAN_INTERVAL_ALARM, default=DEFAULT_SCAN_INTERVAL_ALARM): int,
+                    # Optional cloud control. Leave empty for a purely local setup.
+                    vol.Optional(CONF_CLOUD_ACCESS_TOKEN, default=""): str,
+                    vol.Optional(CONF_CLOUD_REFRESH_TOKEN, default=""): str,
+                    # Range, nicht nur int: eine 0 laesst den Coordinator die Hersteller-Cloud hämmern.
+                    vol.Optional(CONF_CLOUD_SCAN_INTERVAL, default=DEFAULT_CLOUD_SCAN_INTERVAL): vol.All(int, vol.Range(min=30)),
                 }
             ),
             errors=_errors,
+        )
+
+    async def async_step_reauth(
+            self,
+            entry_data: dict[str, Any],
+    ) -> config_entries.FlowResult:
+        """The stored cloud refresh_token died — ask for a fresh one."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+            self,
+            user_input: dict | None = None,
+    ) -> config_entries.FlowResult:
+        """Take a new token pair and reload the entry."""
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    **entry.data,
+                    CONF_CLOUD_ACCESS_TOKEN: user_input[CONF_CLOUD_ACCESS_TOKEN],
+                    CONF_CLOUD_REFRESH_TOKEN: user_input[CONF_CLOUD_REFRESH_TOKEN],
+                },
+            )
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): str,
+                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): str,
+                }
+            ),
         )
 
 
@@ -87,6 +132,11 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                 **self.config_entry.data,
                 SCAN_INTERVAL_OUTPUT: user_input[SCAN_INTERVAL_OUTPUT],
                 SCAN_INTERVAL_ALARM: user_input[SCAN_INTERVAL_ALARM],
+                CONF_CLOUD_ACCESS_TOKEN: user_input.get(CONF_CLOUD_ACCESS_TOKEN, ""),
+                CONF_CLOUD_REFRESH_TOKEN: user_input.get(CONF_CLOUD_REFRESH_TOKEN, ""),
+                CONF_CLOUD_SCAN_INTERVAL: user_input.get(
+                    CONF_CLOUD_SCAN_INTERVAL, DEFAULT_CLOUD_SCAN_INTERVAL
+                ),
             }
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
@@ -112,6 +162,20 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                         SCAN_INTERVAL_ALARM,
                         default=current_alarm_interval,
                     ): int,
+                    vol.Optional(
+                        CONF_CLOUD_ACCESS_TOKEN,
+                        default=self.config_entry.data.get(CONF_CLOUD_ACCESS_TOKEN, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_CLOUD_REFRESH_TOKEN,
+                        default=self.config_entry.data.get(CONF_CLOUD_REFRESH_TOKEN, ""),
+                    ): str,
+                    vol.Optional(
+                        CONF_CLOUD_SCAN_INTERVAL,
+                        default=self.config_entry.data.get(
+                            CONF_CLOUD_SCAN_INTERVAL, DEFAULT_CLOUD_SCAN_INTERVAL
+                        ),
+                    ): vol.All(int, vol.Range(min=30)),
                 }
             ),
         )

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for APsystems EZHI local API integration."""
 import asyncio
+from collections.abc import Mapping
 from typing import Any
 
 from aiohttp import client_exceptions
@@ -8,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -23,11 +25,13 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_ALARM,
     UPDATE_INTERVAL,
     CONF_CLOUD_ACCESS_TOKEN,
+    CONF_CLOUD_DEVICE_ID,
     CONF_CLOUD_REFRESH_TOKEN,
     CONF_CLOUD_SCAN_INTERVAL,
     DEFAULT_CLOUD_SCAN_INTERVAL,
 )
 from .api import APsystemsEZHI
+from .cloud import EzhiCloudApi, EzhiCloudAuthError, EzhiCloudError
 
 
 class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -69,8 +73,12 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_IP_ADDRESS): str,
                     vol.Required(CONF_NAME): str,
                     vol.Optional("check", default=True): bool,
-                    vol.Optional(SCAN_INTERVAL_OUTPUT, default=DEFAULT_SCAN_INTERVAL_OUTPUT): int,
-                    vol.Optional(SCAN_INTERVAL_ALARM, default=DEFAULT_SCAN_INTERVAL_ALARM): int,
+                    vol.Optional(SCAN_INTERVAL_OUTPUT, default=DEFAULT_SCAN_INTERVAL_OUTPUT): vol.All(
+                        int, vol.Range(min=1)
+                    ),
+                    vol.Optional(SCAN_INTERVAL_ALARM, default=DEFAULT_SCAN_INTERVAL_ALARM): vol.All(
+                        int, vol.Range(min=1)
+                    ),
                     # Optional cloud control. Leave empty for a purely local setup.
                     vol.Optional(CONF_CLOUD_ACCESS_TOKEN, default=""): TextSelector(
                         TextSelectorConfig(type=TextSelectorType.PASSWORD)
@@ -78,7 +86,7 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_CLOUD_REFRESH_TOKEN, default=""): TextSelector(
                         TextSelectorConfig(type=TextSelectorType.PASSWORD)
                     ),
-                    # Range, nicht nur int: eine 0 laesst den Coordinator die Hersteller-Cloud hämmern.
+                    # Range, not bare int: a 0 would make the coordinator hammer the vendor cloud.
                     vol.Optional(CONF_CLOUD_SCAN_INTERVAL, default=DEFAULT_CLOUD_SCAN_INTERVAL): vol.All(int, vol.Range(min=30)),
                 }
             ),
@@ -87,7 +95,7 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(
             self,
-            entry_data: dict[str, Any],
+            entry_data: Mapping[str, Any],
     ) -> config_entries.FlowResult:
         """The stored cloud refresh_token died — ask for a fresh one."""
         return await self.async_step_reauth_confirm()
@@ -96,33 +104,60 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self,
             user_input: dict | None = None,
     ) -> config_entries.FlowResult:
-        """Take a new token pair and reload the entry."""
+        """Take a new token pair, verify it, and reload the entry."""
         entry = self._get_reauth_entry()
+        _errors: dict[str, str] = {}
 
         if user_input is not None:
-            self.hass.config_entries.async_update_entry(
-                entry,
-                data={
-                    **entry.data,
-                    CONF_CLOUD_ACCESS_TOKEN: user_input[CONF_CLOUD_ACCESS_TOKEN],
-                    CONF_CLOUD_REFRESH_TOKEN: user_input[CONF_CLOUD_REFRESH_TOKEN],
-                },
-            )
-            await self.hass.config_entries.async_reload(entry.entry_id)
-            return self.async_abort(reason="reauth_successful")
+            device_id = entry.data.get(CONF_CLOUD_DEVICE_ID, "")
+            if device_id:
+                # Cheap: the deviceId is already cached, so this costs one
+                # extra cloud call instead of leaving the user staring at
+                # "Cloud credentials updated" right before the same reauth
+                # dialog reopens on the next failed poll.
+                api = EzhiCloudApi(
+                    session=async_get_clientsession(self.hass),
+                    device_id=device_id,
+                    access_token=user_input[CONF_CLOUD_ACCESS_TOKEN],
+                    refresh_token=user_input[CONF_CLOUD_REFRESH_TOKEN],
+                )
+                try:
+                    await api.async_get_config()
+                except EzhiCloudAuthError:
+                    _errors["base"] = "cloud_auth_failed"
+                except EzhiCloudError as err:
+                    # A transport hiccup or a cloud outage must not stop the
+                    # user from fixing their credentials.
+                    LOGGER.warning(
+                        "Could not verify the new cloud credentials: %s", err
+                    )
+            # No cached device_id -> nothing to call the API with; accept the
+            # tokens unverified rather than blocking on a check that cannot run.
+
+            if not _errors:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={
+                        CONF_CLOUD_ACCESS_TOKEN: user_input[CONF_CLOUD_ACCESS_TOKEN],
+                        CONF_CLOUD_REFRESH_TOKEN: user_input[CONF_CLOUD_REFRESH_TOKEN],
+                    },
+                )
 
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): vol.All(
+                        TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                        vol.Length(min=1),
                     ),
-                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): vol.All(
+                        TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                        vol.Length(min=1),
                     ),
                 }
             ),
+            errors=_errors,
         )
 
 
@@ -173,18 +208,40 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                     vol.Required(
                         SCAN_INTERVAL_OUTPUT,
                         default=current_output_interval,
-                    ): int,
+                    ): vol.All(int, vol.Range(min=1)),
                     vol.Required(
                         SCAN_INTERVAL_ALARM,
                         default=current_alarm_interval,
-                    ): int,
+                    ): vol.All(int, vol.Range(min=1)),
+                    # description=suggested_value (not default=) is deliberate:
+                    # the frontend strips empty-string fields before sending, so
+                    # a default would make voluptuous silently reinsert the old
+                    # token whenever the user clears the field to disable the
+                    # cloud layer -- default= would make .get(key, "") below
+                    # unreachable. suggested_value pre-fills the same way but
+                    # leaves the key genuinely absent when submitted empty.
+                    #
+                    # ponytail: lost-update window -- if this dialog was opened
+                    # before a concurrent reauth wrote a fresh token pair, the
+                    # suggested_value below is already stale, and submitting
+                    # this form unchanged overwrites the fresh pair with it.
+                    # Narrow (both flows are human-timescale and rare together);
+                    # the remedy is just another reauth, not worth a sentinel.
                     vol.Optional(
                         CONF_CLOUD_ACCESS_TOKEN,
-                        default=self.config_entry.data.get(CONF_CLOUD_ACCESS_TOKEN, ""),
+                        description={
+                            "suggested_value": self.config_entry.data.get(
+                                CONF_CLOUD_ACCESS_TOKEN, ""
+                            )
+                        },
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                     vol.Optional(
                         CONF_CLOUD_REFRESH_TOKEN,
-                        default=self.config_entry.data.get(CONF_CLOUD_REFRESH_TOKEN, ""),
+                        description={
+                            "suggested_value": self.config_entry.data.get(
+                                CONF_CLOUD_REFRESH_TOKEN, ""
+                            )
+                        },
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                     vol.Optional(
                         CONF_CLOUD_SCAN_INTERVAL,

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -300,8 +300,13 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                     # Filling these in fetches a fresh token pair and writes it
                     # into the two fields above. Neither is persisted, which is
                     # also why they never come back pre-filled.
+                    #
+                    # TEXT, not EMAIL: loginEncrypt wants the EMA account's
+                    # *username*. The e-mail address is rejected. An email
+                    # selector would put the wrong keyboard on mobile and
+                    # invite exactly the credential that does not work.
                     vol.Optional(CONF_CLOUD_USERNAME): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.EMAIL)
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
                     ),
                     vol.Optional(CONF_CLOUD_PASSWORD): TextSelector(
                         TextSelectorConfig(type=TextSelectorType.PASSWORD)

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -26,12 +26,14 @@ from .const import (
     UPDATE_INTERVAL,
     CONF_CLOUD_ACCESS_TOKEN,
     CONF_CLOUD_DEVICE_ID,
+    CONF_CLOUD_PASSWORD,
     CONF_CLOUD_REFRESH_TOKEN,
     CONF_CLOUD_SCAN_INTERVAL,
+    CONF_CLOUD_USERNAME,
     DEFAULT_CLOUD_SCAN_INTERVAL,
 )
 from .api import APsystemsEZHI
-from .cloud import EzhiCloudApi, EzhiCloudAuthError, EzhiCloudError
+from .cloud import EzhiCloudApi, EzhiCloudAuthError, EzhiCloudError, async_login
 
 
 class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -189,14 +191,47 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
         """Manage the device options."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            # Update the config entry data with new intervals
+            access_token = user_input.get(CONF_CLOUD_ACCESS_TOKEN, "")
+            refresh_token = user_input.get(CONF_CLOUD_REFRESH_TOKEN, "")
+
+            # Credentials, when given, win over whatever is in the token
+            # fields: the user filled them in precisely to replace those.
+            username = (user_input.get(CONF_CLOUD_USERNAME) or "").strip()
+            password = user_input.get(CONF_CLOUD_PASSWORD) or ""
+            if username and password:
+                try:
+                    tokens = await async_login(
+                        async_get_clientsession(self.hass), username, password
+                    )
+                except EzhiCloudAuthError as err:
+                    LOGGER.warning("EZHI cloud login rejected: %s", err)
+                    errors["base"] = "invalid_auth"
+                except EzhiCloudError as err:
+                    LOGGER.warning("EZHI cloud login failed: %s", err)
+                    errors["base"] = "cannot_connect"
+                else:
+                    access_token = tokens["access_token"]
+                    refresh_token = tokens["refresh_token"]
+            elif username or password:
+                # Half a credential pair is a typo, not an intent to clear the
+                # cloud layer -- clearing is done by emptying the token fields.
+                errors["base"] = "incomplete_credentials"
+
+            if errors:
+                return self.async_show_form(
+                    step_id="device_options",
+                    data_schema=self._device_options_schema(),
+                    errors=errors,
+                )
+
             new_data = {
                 **self.config_entry.data,
                 SCAN_INTERVAL_OUTPUT: user_input[SCAN_INTERVAL_OUTPUT],
                 SCAN_INTERVAL_ALARM: user_input[SCAN_INTERVAL_ALARM],
-                CONF_CLOUD_ACCESS_TOKEN: user_input.get(CONF_CLOUD_ACCESS_TOKEN, ""),
-                CONF_CLOUD_REFRESH_TOKEN: user_input.get(CONF_CLOUD_REFRESH_TOKEN, ""),
+                CONF_CLOUD_ACCESS_TOKEN: access_token,
+                CONF_CLOUD_REFRESH_TOKEN: refresh_token,
                 CONF_CLOUD_SCAN_INTERVAL: user_input.get(
                     CONF_CLOUD_SCAN_INTERVAL, DEFAULT_CLOUD_SCAN_INTERVAL
                 ),
@@ -211,14 +246,18 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
             # nothing reads them and a later reauth would leave them stale.
             return self.async_create_entry(title="", data={})
 
+        return self.async_show_form(
+            step_id="device_options", data_schema=self._device_options_schema()
+        )
+
+    def _device_options_schema(self) -> vol.Schema:
+        """The options form. Built here so the error path can re-show it."""
         # Get current intervals from config entry (with legacy fallback)
         legacy_interval = self.config_entry.data.get(UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL_OUTPUT)
         current_output_interval = self.config_entry.data.get(SCAN_INTERVAL_OUTPUT, legacy_interval)
         current_alarm_interval = self.config_entry.data.get(SCAN_INTERVAL_ALARM, DEFAULT_SCAN_INTERVAL_ALARM)
 
-        return self.async_show_form(
-            step_id="device_options",
-            data_schema=vol.Schema(
+        return vol.Schema(
                 {
                     vol.Required(
                         SCAN_INTERVAL_OUTPUT,
@@ -258,6 +297,15 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                             )
                         },
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                    # Filling these in fetches a fresh token pair and writes it
+                    # into the two fields above. Neither is persisted, which is
+                    # also why they never come back pre-filled.
+                    vol.Optional(CONF_CLOUD_USERNAME): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.EMAIL)
+                    ),
+                    vol.Optional(CONF_CLOUD_PASSWORD): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
                     vol.Optional(
                         CONF_CLOUD_SCAN_INTERVAL,
                         default=self.config_entry.data.get(
@@ -265,5 +313,4 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                         ),
                     ): vol.All(int, vol.Range(min=30)),
                 }
-            ),
         )

--- a/custom_components/apsystems_ezhi_local/config_flow.py
+++ b/custom_components/apsystems_ezhi_local/config_flow.py
@@ -8,6 +8,11 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     DOMAIN,
@@ -67,8 +72,12 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(SCAN_INTERVAL_OUTPUT, default=DEFAULT_SCAN_INTERVAL_OUTPUT): int,
                     vol.Optional(SCAN_INTERVAL_ALARM, default=DEFAULT_SCAN_INTERVAL_ALARM): int,
                     # Optional cloud control. Leave empty for a purely local setup.
-                    vol.Optional(CONF_CLOUD_ACCESS_TOKEN, default=""): str,
-                    vol.Optional(CONF_CLOUD_REFRESH_TOKEN, default=""): str,
+                    vol.Optional(CONF_CLOUD_ACCESS_TOKEN, default=""): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                    vol.Optional(CONF_CLOUD_REFRESH_TOKEN, default=""): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
                     # Range, nicht nur int: eine 0 laesst den Coordinator die Hersteller-Cloud hämmern.
                     vol.Optional(CONF_CLOUD_SCAN_INTERVAL, default=DEFAULT_CLOUD_SCAN_INTERVAL): vol.All(int, vol.Range(min=30)),
                 }
@@ -106,8 +115,12 @@ class APsystemsEZHILocalAPIFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): str,
-                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): str,
+                    vol.Required(CONF_CLOUD_ACCESS_TOKEN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                    vol.Required(CONF_CLOUD_REFRESH_TOKEN): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
                 }
             ),
         )
@@ -143,7 +156,10 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
             )
             # Reload the integration to apply new intervals
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            return self.async_create_entry(title="", data=user_input)
+            # Everything is persisted to entry.data above; passing user_input
+            # here would duplicate both cloud tokens into entry.options, where
+            # nothing reads them and a later reauth would leave them stale.
+            return self.async_create_entry(title="", data={})
 
         # Get current intervals from config entry (with legacy fallback)
         legacy_interval = self.config_entry.data.get(UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL_OUTPUT)
@@ -165,11 +181,11 @@ class APsystemsEZHIOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_CLOUD_ACCESS_TOKEN,
                         default=self.config_entry.data.get(CONF_CLOUD_ACCESS_TOKEN, ""),
-                    ): str,
+                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                     vol.Optional(
                         CONF_CLOUD_REFRESH_TOKEN,
                         default=self.config_entry.data.get(CONF_CLOUD_REFRESH_TOKEN, ""),
-                    ): str,
+                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                     vol.Optional(
                         CONF_CLOUD_SCAN_INTERVAL,
                         default=self.config_entry.data.get(

--- a/custom_components/apsystems_ezhi_local/const.py
+++ b/custom_components/apsystems_ezhi_local/const.py
@@ -27,6 +27,10 @@ CONF_CLOUD_REFRESH_TOKEN = "cloud_refresh_token"
 CONF_CLOUD_SCAN_INTERVAL = "cloud_scan_interval"
 DEFAULT_CLOUD_SCAN_INTERVAL = 60
 
+# Cached from the local API, not user-entered: the cloud layer needs a deviceId
+# and must not be disabled for good by one transient local-API failure.
+CONF_CLOUD_DEVICE_ID = "cloud_device_id"
+
 CLOUD_COORDINATOR = "CLOUD_COORDINATOR"
 
 # systemMode values. Only these two are verified; mode 3 exists but its meaning

--- a/custom_components/apsystems_ezhi_local/const.py
+++ b/custom_components/apsystems_ezhi_local/const.py
@@ -33,11 +33,27 @@ CONF_CLOUD_DEVICE_ID = "cloud_device_id"
 
 CLOUD_COORDINATOR = "CLOUD_COORDINATOR"
 
-# systemMode values. Only these two are verified; mode 3 exists but its meaning
-# is unconfirmed, so it is deliberately not offered.
+# systemMode values, read off the vendor app's own scenario picker
+# ({text: $t("applicationSceN"), value: N}) and cross-checked against both the
+# per-mode payload field sets and screenshots of the live app.
+#
+# TRAP: the i18n key numbers are NOT the mode numbers. applicationSce6 is mode
+# 5 and applicationSce5 is mode 3 -- mapping by key name silently swaps two
+# modes. See docs/ezhi-cloud-api-from-app-source.md.
+SYSTEM_MODE_BALCONY = "1"
 SYSTEM_MODE_PORTABLE = "2"
+SYSTEM_MODE_AI = "3"
 SYSTEM_MODE_LOCAL = "4"
+SYSTEM_MODE_BALCONY_AC = "5"
+SYSTEM_MODE_NO_BATTERY = "6"
+
+# Mode 5 is deliberately absent: it is the AC-coupled hardware variant, and the
+# app only offers it to devices that have it. Offering a mode the hardware does
+# not support is a worse failure than not offering it at all.
 SYSTEM_MODE_OPTIONS = {
+    "Balcony Storage": SYSTEM_MODE_BALCONY,
     "Portable": SYSTEM_MODE_PORTABLE,
+    "AI": SYSTEM_MODE_AI,
     "Local": SYSTEM_MODE_LOCAL,
+    "No Battery": SYSTEM_MODE_NO_BATTERY,
 }

--- a/custom_components/apsystems_ezhi_local/const.py
+++ b/custom_components/apsystems_ezhi_local/const.py
@@ -24,6 +24,10 @@ MAX_VALUE = 1200
 # local API is read-only apart from setPower. See docs/ezhi-cloud-api-map.md.
 CONF_CLOUD_ACCESS_TOKEN = "cloud_access_token"
 CONF_CLOUD_REFRESH_TOKEN = "cloud_refresh_token"
+# Only ever read out of the options form to mint a token pair -- deliberately
+# not persisted, so the account password never lands in .storage.
+CONF_CLOUD_USERNAME = "cloud_username"
+CONF_CLOUD_PASSWORD = "cloud_password"
 CONF_CLOUD_SCAN_INTERVAL = "cloud_scan_interval"
 DEFAULT_CLOUD_SCAN_INTERVAL = 60
 

--- a/custom_components/apsystems_ezhi_local/const.py
+++ b/custom_components/apsystems_ezhi_local/const.py
@@ -21,7 +21,7 @@ MAX_VALUE = 1200
 
 # --- Optional cloud control layer -------------------------------------------
 # Control commands (on/off, mode, SOC limits) exist only in the EMA cloud; the
-# local API is read-only apart from setPower. See docs/ezhi-cloud-api-map.md.
+# local API is read-only apart from setPower.
 CONF_CLOUD_ACCESS_TOKEN = "cloud_access_token"
 CONF_CLOUD_REFRESH_TOKEN = "cloud_refresh_token"
 # Only ever read out of the options form to mint a token pair -- deliberately
@@ -43,7 +43,7 @@ CLOUD_COORDINATOR = "CLOUD_COORDINATOR"
 #
 # TRAP: the i18n key numbers are NOT the mode numbers. applicationSce6 is mode
 # 5 and applicationSce5 is mode 3 -- mapping by key name silently swaps two
-# modes. See docs/ezhi-cloud-api-from-app-source.md.
+# modes.
 SYSTEM_MODE_BALCONY = "1"
 SYSTEM_MODE_PORTABLE = "2"
 SYSTEM_MODE_AI = "3"

--- a/custom_components/apsystems_ezhi_local/const.py
+++ b/custom_components/apsystems_ezhi_local/const.py
@@ -18,3 +18,22 @@ DEFAULT_SCAN_INTERVAL_ALARM = 60
 # Power limits
 MIN_VALUE = -1200
 MAX_VALUE = 1200
+
+# --- Optional cloud control layer -------------------------------------------
+# Control commands (on/off, mode, SOC limits) exist only in the EMA cloud; the
+# local API is read-only apart from setPower. See docs/ezhi-cloud-api-map.md.
+CONF_CLOUD_ACCESS_TOKEN = "cloud_access_token"
+CONF_CLOUD_REFRESH_TOKEN = "cloud_refresh_token"
+CONF_CLOUD_SCAN_INTERVAL = "cloud_scan_interval"
+DEFAULT_CLOUD_SCAN_INTERVAL = 60
+
+CLOUD_COORDINATOR = "CLOUD_COORDINATOR"
+
+# systemMode values. Only these two are verified; mode 3 exists but its meaning
+# is unconfirmed, so it is deliberately not offered.
+SYSTEM_MODE_PORTABLE = "2"
+SYSTEM_MODE_LOCAL = "4"
+SYSTEM_MODE_OPTIONS = {
+    "Portable": SYSTEM_MODE_PORTABLE,
+    "Local": SYSTEM_MODE_LOCAL,
+}

--- a/custom_components/apsystems_ezhi_local/entity.py
+++ b/custom_components/apsystems_ezhi_local/entity.py
@@ -1,0 +1,50 @@
+"""Shared base for the cloud-backed control entities.
+
+Kept out of const.py: this needs Home Assistant imports (CoordinatorEntity,
+DeviceInfo), and const.py stays import-light on purpose so cloud.py -- which
+is deliberately free of homeassistant imports -- never has a reason to touch
+this module.
+
+Scoped to the three cloud entity classes only (switch.py, select.py,
+number.py's EzhiCloudSocNumber). sensor.py, binary_sensor.py and the existing
+local PowerLimit number have their own device_info variants and are not
+touched by this base.
+"""
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+class EzhiCloudEntity(CoordinatorEntity):
+    """Common device binding and naming for a cloud-backed control entity.
+
+    `unique_id_suffix` and `name_suffix` are the only things that differ
+    between the on/off switch, the system-mode select and the two SOC
+    numbers -- everything else (device identity, manufacturer/model, the
+    "apsystems_<device>_cloud_<suffix>" unique-id convention) was previously
+    copied verbatim into all three.
+    """
+
+    def __init__(
+        self,
+        coordinator,
+        device_name: str,
+        unique_id_suffix: str,
+        name_suffix: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._device_name = device_name
+        self._attr_name = f"APsystems {device_name} {name_suffix}"
+        self._attr_unique_id = f"apsystems_{device_name}_cloud_{unique_id_suffix}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_name)},
+            name=self._device_name,
+            manufacturer="APsystems",
+            model="EZHI",
+        )

--- a/custom_components/apsystems_ezhi_local/entity.py
+++ b/custom_components/apsystems_ezhi_local/entity.py
@@ -17,6 +17,20 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+# Deadline for a service-call write to the cloud (switch/select/number's
+# async_turn_on/off, async_select_option, async_set_native_value). This is
+# not cloud.py's own per-HTTP-round-trip timeout (EzhiCloudApi's self._timeout,
+# 15 s default): cloud.py's ponytail: comment ties its no-wrapping-deadline
+# stance to DataUpdateCoordinator being the only caller, and worst case per
+# attempt is already ~4x that. select.py/number.py's writes are a GET+POST,
+# so unguarded worst case is 60-120 s. Without this, a slow cloud leaves the
+# service call hanging, the frontend times out, the user reads that as
+# failure and presses again -- a second write to a hybrid inverter, the
+# exact hazard _attr_assumed_state exists to reduce, arriving through
+# another door. 30 s surfaces that risk as a clear error well before the
+# true worst case.
+CLOUD_WRITE_TIMEOUT_S = 30
+
 
 class EzhiCloudEntity(CoordinatorEntity):
     """Common device binding and naming for a cloud-backed control entity.

--- a/custom_components/apsystems_ezhi_local/manifest.json
+++ b/custom_components/apsystems_ezhi_local/manifest.json
@@ -6,6 +6,6 @@
   "requirements": [],
   "dependencies": [],
   "codeowners": ["@kamilkosek"],
-  "version": "0.2.0",
+  "version": "0.3.0",
   "iot_class": "local_polling"
 }

--- a/custom_components/apsystems_ezhi_local/manifest.json
+++ b/custom_components/apsystems_ezhi_local/manifest.json
@@ -5,7 +5,9 @@
   "documentation": "https://github.com/kamilkosek/EZHI",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@kamilkosek"],
-  "version": "0.3.0",
+  "codeowners": [
+    "@kamilkosek"
+  ],
+  "version": "0.4.0",
   "iot_class": "local_polling"
 }

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -14,11 +14,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CLOUD_COORDINATOR, DOMAIN, MAX_VALUE, MIN_VALUE
 from .api import APsystemsEZHI
 from .cloud import EzhiCloudError
+from .entity import EzhiCloudEntity
 
 
 async def async_setup_entry(
@@ -128,7 +128,7 @@ def _safe_float(raw) -> float | None:
         return None
 
 
-class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
+class EzhiCloudSocNumber(EzhiCloudEntity, NumberEntity):
     """One of the two SOC bounds, written through the EMA cloud.
 
     The socLimit endpoint takes both bounds at once. Rather than pairing them
@@ -147,20 +147,8 @@ class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
     _attr_mode = NumberMode.BOX
 
     def __init__(self, coordinator, device_name: str, key: str, label: str):
-        super().__init__(coordinator)
-        self._device_name = device_name
+        super().__init__(coordinator, device_name, key.lower(), label)
         self._key = key  # "socMin" or "socMax"
-        self._attr_name = f"APsystems {device_name} {label}"
-        self._attr_unique_id = f"apsystems_{device_name}_cloud_{key.lower()}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_name)},
-            name=self._device_name,
-            manufacturer="APsystems",
-            model="EZHI",
-        )
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -1,14 +1,10 @@
 """Number platform for APsystems EZHI local API integration."""
 from __future__ import annotations
 
-import asyncio
-
 from aiohttp import client_exceptions
-import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.number import (
-    PLATFORM_SCHEMA,
     NumberDeviceClass,
     NumberEntity,
     NumberMode,
@@ -16,27 +12,19 @@ from homeassistant.components.number import (
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CLOUD_COORDINATOR, DOMAIN, MAX_VALUE, MIN_VALUE
 from .api import APsystemsEZHI
 from .cloud import EzhiCloudError
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_IP_ADDRESS): cv.string,
-    vol.Optional(CONF_NAME, default="ezhi"): cv.string
-})
-
 
 async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: config_entries.ConfigEntry,
         add_entities: AddEntitiesCallback,
-        discovery_info: DiscoveryInfoType | None = None
 ) -> None:
     """Set up the number platform."""
     config = hass.data[DOMAIN][config_entry.entry_id]
@@ -126,6 +114,20 @@ class PowerLimit(NumberEntity):
 _KEY_TO_KWARG = {"socMin": "soc_min", "socMax": "soc_max"}
 
 
+def _safe_float(raw) -> float | None:
+    """Parse a raw cloud value to float, tolerating both the missing case and
+    a malformed one the same way. Before this, a raw of None returned a
+    friendly None (-> entity state "unknown") but a non-numeric string raised
+    a bare ValueError as a traceback -- inconsistent handling of two flavours
+    of "this field isn't usable yet"."""
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
     """One of the two SOC bounds, written through the EMA cloud.
 
@@ -162,13 +164,15 @@ class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
 
     @property
     def native_value(self) -> float | None:
-        raw = (self.coordinator.data or {}).get(self._key)
-        return None if raw is None else float(raw)
+        return _safe_float((self.coordinator.data or {}).get(self._key))
 
     async def async_set_native_value(self, value: float) -> None:
+        # round(), not int(): HA validates native_min/max_value but not
+        # native_step, so a slider drag landing on e.g. 20.7 would otherwise
+        # be silently truncated to 20 instead of rounded to 21.
         try:
             await self.coordinator.api.async_set_soc_limit(
-                **{_KEY_TO_KWARG[self._key]: int(value)}
+                **{_KEY_TO_KWARG[self._key]: round(value)}
             )
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -11,16 +11,20 @@ from homeassistant.components.number import (
     PLATFORM_SCHEMA,
     NumberDeviceClass,
     NumberEntity,
+    NumberMode,
 )
-from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MAX_VALUE, MIN_VALUE
+from .const import CLOUD_COORDINATOR, DOMAIN, MAX_VALUE, MIN_VALUE
 from .api import APsystemsEZHI
+from .cloud import EzhiCloudError
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_IP_ADDRESS): cv.string,
@@ -41,6 +45,13 @@ async def async_setup_entry(
     numbers = [
         PowerLimit(api, device_name=config[CONF_NAME], sensor_name="On-Grid Power", sensor_id="max_output_power")
     ]
+
+    cloud_coordinator = config.get(CLOUD_COORDINATOR)
+    if cloud_coordinator is not None:
+        numbers.extend([
+            EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMin", "SOC Minimum"),
+            EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMax", "SOC Maximum"),
+        ])
 
     add_entities(numbers, True)
 
@@ -104,3 +115,61 @@ class PowerLimit(NumberEntity):
             manufacturer="APsystems",
             model="EZHI",
         )
+
+
+class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
+    """One of the two SOC bounds, written through the EMA cloud.
+
+    The socLimit endpoint takes both bounds at once, so setting one always sends
+    the other one's current value along — otherwise every edit would clobber it.
+    """
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_device_class = NumberDeviceClass.BATTERY
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator, device_name: str, key: str, label: str):
+        super().__init__(coordinator)
+        self._device_name = device_name
+        self._key = key  # "socMin" or "socMax"
+        self._attr_name = f"APsystems {device_name} {label}"
+        self._attr_unique_id = f"apsystems_{device_name}_cloud_{key.lower()}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_name)},
+            name=self._device_name,
+            manufacturer="APsystems",
+            model="EZHI",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        raw = (self.coordinator.data or {}).get(self._key)
+        return None if raw is None else float(raw)
+
+    async def async_set_native_value(self, value: float) -> None:
+        config = self.coordinator.data or {}
+        bounds = {"socMin": config.get("socMin"), "socMax": config.get("socMax")}
+        bounds[self._key] = int(value)
+
+        if bounds["socMin"] is None or bounds["socMax"] is None:
+            raise HomeAssistantError(
+                "the EZHI cloud config has not loaded yet — try again shortly"
+            )
+
+        soc_min, soc_max = int(bounds["socMin"]), int(bounds["socMax"])
+        if soc_min >= soc_max:
+            raise HomeAssistantError(
+                f"SOC minimum ({soc_min}%) must stay below the maximum ({soc_max}%)"
+            )
+
+        try:
+            await self.coordinator.api.async_set_soc_limit(soc_min, soc_max)
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 
 from aiohttp import client_exceptions
 
@@ -11,7 +12,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberMode,
 )
-from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, PERCENTAGE
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, PERCENTAGE, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -49,6 +50,9 @@ async def async_setup_entry(
         add_entities([
             EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMin", "SOC Minimum"),
             EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMax", "SOC Maximum"),
+            EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["userSetPower"]),
+            EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["dischargeProtection"]),
+            EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["powerLimit"]),
         ])
 
 
@@ -172,6 +176,110 @@ class EzhiCloudSocNumber(EzhiCloudEntity, NumberEntity):
             raise HomeAssistantError(
                 f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
                 "-- the SOC limit change may or may not have been applied"
+            ) from err
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        await self.coordinator.async_request_refresh()
+
+
+@dataclass(frozen=True)
+class _SystemModeNumber:
+    """Everything that differs between the three systemMode-backed numbers."""
+
+    key: str
+    label: str
+    unique_id: str
+    minimum: float
+    maximum: float
+    step: float
+    unit: str
+    device_class: NumberDeviceClass
+    icon: str
+    note: str
+
+
+# Ranges come from the vendor app's own bounds, not from guesswork:
+#   userSetPower  -- the preset output power; app default 200 W, ceiling is
+#                    powerLimit. Kept at the device ceiling rather than the
+#                    live powerLimit so lowering powerLimit cannot strand the
+#                    entity above its own max.
+#   powerLimit    -- the app carries minPower 800 / maxPower 1200, with 1200
+#                    only reachable while "high power mode" (maxPowerFlag) is
+#                    on. That flag is not exposed here, so a write above 800
+#                    may be clamped by the device.
+#   dischargeProtection -- percent, and cloud.py refuses anything under
+#                    socMin + 2, the same rule the app enforces.
+SYSTEM_MODE_NUMBERS = {
+    "userSetPower": _SystemModeNumber(
+        key="userSetPower", label="Preset Output Power", unique_id="user_set_power",
+        minimum=0, maximum=1200, step=10, unit=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER, icon="mdi:transmission-tower-export",
+        note="Preset discharge power to the grid side. Capped by the power limit.",
+    ),
+    "dischargeProtection": _SystemModeNumber(
+        key="dischargeProtection", label="Discharge Protection", unique_id="discharge_protection",
+        minimum=0, maximum=100, step=1, unit=PERCENTAGE,
+        device_class=NumberDeviceClass.BATTERY, icon="mdi:battery-alert-variant-outline",
+        note=(
+            "Discharging stops below the minimum SOC and only resumes once the "
+            "battery is back above this threshold. Must be at least 2% above the "
+            "minimum SOC; a lower value is refused rather than silently clamped."
+        ),
+    ),
+    "powerLimit": _SystemModeNumber(
+        key="powerLimit", label="Power Limit", unique_id="power_limit",
+        minimum=0, maximum=1200, step=10, unit=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER, icon="mdi:speedometer",
+        note=(
+            "Maximum output power ceiling. The device default is 800 W; 1200 W "
+            "needs the app's high-power mode, which this integration does not "
+            "expose -- a higher value may be clamped by the device. This is NOT "
+            "the same as the local 'On-Grid Power' setpoint."
+        ),
+    ),
+}
+
+
+class EzhiCloudSystemModeNumber(EzhiCloudEntity, NumberEntity):
+    """A numeric field inside the systemMode config blob.
+
+    All three share one write path (async_set_system_mode with a single
+    keyword), so they share one class -- the only differences are the range,
+    the unit and the label, which live in _SystemModeNumber above.
+    """
+
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator, device_name: str, spec: _SystemModeNumber):
+        super().__init__(coordinator, device_name, spec.unique_id, spec.label)
+        self._spec = spec
+        self._attr_native_min_value = spec.minimum
+        self._attr_native_max_value = spec.maximum
+        self._attr_native_step = spec.step
+        self._attr_native_unit_of_measurement = spec.unit
+        self._attr_device_class = spec.device_class
+        self._attr_icon = spec.icon
+
+    @property
+    def native_value(self) -> float | None:
+        return _safe_float((self.coordinator.data or {}).get(self._spec.key))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        return {"note": self._spec.note}
+
+    async def async_set_native_value(self, value: float) -> None:
+        try:
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                # round(), not int(): HA validates min/max but not step, so a
+                # slider landing on 20.7 would otherwise truncate to 20.
+                await self.coordinator.api.async_set_system_mode(
+                    **{self._spec.key: round(value)}
+                )
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                f"-- the {self._spec.label} change may or may not have been applied"
             ) from err
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -52,7 +52,6 @@ async def async_setup_entry(
             EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMax", "SOC Maximum"),
             EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["userSetPower"]),
             EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["dischargeProtection"]),
-            EzhiCloudSystemModeNumber(cloud_coordinator, config[CONF_NAME], SYSTEM_MODE_NUMBERS["powerLimit"]),
         ])
 
 
@@ -184,7 +183,7 @@ class EzhiCloudSocNumber(EzhiCloudEntity, NumberEntity):
 
 @dataclass(frozen=True)
 class _SystemModeNumber:
-    """Everything that differs between the three systemMode-backed numbers."""
+    """Everything that differs between the systemMode-backed numbers."""
 
     key: str
     label: str
@@ -203,10 +202,18 @@ class _SystemModeNumber:
 #                    powerLimit. Kept at the device ceiling rather than the
 #                    live powerLimit so lowering powerLimit cannot strand the
 #                    entity above its own max.
-#   powerLimit    -- the app carries minPower 800 / maxPower 1200, with 1200
-#                    only reachable while "high power mode" (maxPowerFlag) is
-#                    on. That flag is not exposed here, so a write above 800
-#                    may be clamped by the device.
+#
+# powerLimit deliberately has NO entity here. It looks like a number and is
+# not one: the vendor app only ever assigns it minPower (800) or maxPower
+# (1200) from a "high power mode" toggle -- never a free value. That toggle
+# also (a) shows a disclaimer that 1200 W "may cause the device output to
+# exceed regulatory limits for grid connection", with the legal risk on the
+# user, (b) travels via remote/ezInverter/maxPower/{id} plus a maxPowerFlag
+# this client never sets, and (c) on the way down rewrites every schedule
+# entry above 800 W. Shipping a 0-1200 slider would have been a guess at all
+# three. cloud.py still accepts powerLimit as a settable field, so building
+# the real toggle later needs no change there -- just the maxPower payload,
+# which is one targeted capture away.
 #   dischargeProtection -- percent, and cloud.py refuses anything under
 #                    socMin + 2, the same rule the app enforces.
 SYSTEM_MODE_NUMBERS = {
@@ -226,26 +233,15 @@ SYSTEM_MODE_NUMBERS = {
             "minimum SOC; a lower value is refused rather than silently clamped."
         ),
     ),
-    "powerLimit": _SystemModeNumber(
-        key="powerLimit", label="Power Limit", unique_id="power_limit",
-        minimum=0, maximum=1200, step=10, unit=UnitOfPower.WATT,
-        device_class=NumberDeviceClass.POWER, icon="mdi:speedometer",
-        note=(
-            "Maximum output power ceiling. The device default is 800 W; 1200 W "
-            "needs the app's high-power mode, which this integration does not "
-            "expose -- a higher value may be clamped by the device. This is NOT "
-            "the same as the local 'On-Grid Power' setpoint."
-        ),
-    ),
 }
 
 
 class EzhiCloudSystemModeNumber(EzhiCloudEntity, NumberEntity):
     """A numeric field inside the systemMode config blob.
 
-    All three share one write path (async_set_system_mode with a single
-    keyword), so they share one class -- the only differences are the range,
-    the unit and the label, which live in _SystemModeNumber above.
+    They share one write path (async_set_system_mode with a single keyword),
+    so they share one class -- the only differences are the range, the unit
+    and the label, which live in _SystemModeNumber above.
     """
 
     _attr_mode = NumberMode.BOX

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -206,14 +206,18 @@ class _SystemModeNumber:
 # powerLimit deliberately has NO entity here. It looks like a number and is
 # not one: the vendor app only ever assigns it minPower (800) or maxPower
 # (1200) from a "high power mode" toggle -- never a free value. That toggle
-# also (a) shows a disclaimer that 1200 W "may cause the device output to
-# exceed regulatory limits for grid connection", with the legal risk on the
-# user, (b) travels via remote/ezInverter/maxPower/{id} plus a maxPowerFlag
-# this client never sets, and (c) on the way down rewrites every schedule
-# entry above 800 W. Shipping a 0-1200 slider would have been a guess at all
-# three. cloud.py still accepts powerLimit as a settable field, so building
-# the real toggle later needs no change there -- just the maxPower payload,
-# which is one targeted capture away.
+# shows a disclaimer that 1200 W "may cause the device output to exceed
+# regulatory limits for grid connection", with the legal risk on the user, and
+# on the way down it rewrites every schedule entry above 800 W. A 0-1200
+# slider would have offered values the device never accepts, with no
+# acknowledgement in front of the one that carries the disclaimer.
+#
+# It is the set_high_power_mode service instead, and the current value is
+# readable as a sensor. An earlier version of this comment claimed the write
+# went through remote/ezInverter/maxPower/{id} with a maxPowerFlag; that was
+# wrong and is corrected in cloud.py next to HIGH_POWER_LIMIT -- that endpoint
+# is a GET asking what ceiling the account may use, and powerLimit travels in
+# the ordinary systemMode payload.
 #   dischargeProtection -- percent, and cloud.py refuses anything under
 #                    socMin + 2, the same rule the app enforces.
 SYSTEM_MODE_NUMBERS = {

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -1,6 +1,8 @@
 """Number platform for APsystems EZHI local API integration."""
 from __future__ import annotations
 
+import asyncio
+
 from aiohttp import client_exceptions
 
 from homeassistant import config_entries
@@ -18,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CLOUD_COORDINATOR, DOMAIN, MAX_VALUE, MIN_VALUE
 from .api import APsystemsEZHI
 from .cloud import EzhiCloudError
-from .entity import EzhiCloudEntity
+from .entity import CLOUD_WRITE_TIMEOUT_S, EzhiCloudEntity
 
 
 async def async_setup_entry(
@@ -159,9 +161,18 @@ class EzhiCloudSocNumber(EzhiCloudEntity, NumberEntity):
         # native_step, so a slider drag landing on e.g. 20.7 would otherwise
         # be silently truncated to 20 instead of rounded to 21.
         try:
-            await self.coordinator.api.async_set_soc_limit(
-                **{_KEY_TO_KWARG[self._key]: round(value)}
-            )
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                # async_set_soc_limit re-reads (a GET) before it posts, same
+                # as async_set_system_mode -- unguarded worst case is roughly
+                # double a single-call write.
+                await self.coordinator.api.async_set_soc_limit(
+                    **{_KEY_TO_KWARG[self._key]: round(value)}
+                )
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                "-- the SOC limit change may or may not have been applied"
+            ) from err
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -117,11 +117,18 @@ class PowerLimit(NumberEntity):
         )
 
 
+_KEY_TO_KWARG = {"socMin": "soc_min", "socMax": "soc_max"}
+
+
 class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
     """One of the two SOC bounds, written through the EMA cloud.
 
-    The socLimit endpoint takes both bounds at once, so setting one always sends
-    the other one's current value along — otherwise every edit would clobber it.
+    The socLimit endpoint takes both bounds at once. Rather than pairing them
+    up here from `coordinator.data` (which can be up to a poll interval old),
+    only this entity's own bound is sent -- async_set_soc_limit re-reads the
+    other one fresh. That keeps the untestable pairing logic out of this file
+    (no HA harness here) and in cloud.py, where it is covered by
+    tests/test_cloud.py.
     """
 
     _attr_native_min_value = 0
@@ -153,23 +160,10 @@ class EzhiCloudSocNumber(CoordinatorEntity, NumberEntity):
         return None if raw is None else float(raw)
 
     async def async_set_native_value(self, value: float) -> None:
-        config = self.coordinator.data or {}
-        bounds = {"socMin": config.get("socMin"), "socMax": config.get("socMax")}
-        bounds[self._key] = int(value)
-
-        if bounds["socMin"] is None or bounds["socMax"] is None:
-            raise HomeAssistantError(
-                "the EZHI cloud config has not loaded yet — try again shortly"
-            )
-
-        soc_min, soc_max = int(bounds["socMin"]), int(bounds["socMax"])
-        if soc_min >= soc_max:
-            raise HomeAssistantError(
-                f"SOC minimum ({soc_min}%) must stay below the maximum ({soc_max}%)"
-            )
-
         try:
-            await self.coordinator.api.async_set_soc_limit(soc_min, soc_max)
+            await self.coordinator.api.async_set_soc_limit(
+                **{_KEY_TO_KWARG[self._key]: int(value)}
+            )
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -42,18 +42,24 @@ async def async_setup_entry(
     config = hass.data[DOMAIN][config_entry.entry_id]
     api = APsystemsEZHI(ip_address=config[CONF_IP_ADDRESS])
 
-    numbers = [
-        PowerLimit(api, device_name=config[CONF_NAME], sensor_name="On-Grid Power", sensor_id="max_output_power")
-    ]
+    # update_before_add=True: PowerLimit is a plain, should_poll=True
+    # NumberEntity and would otherwise sit at `unknown` until its first poll.
+    add_entities([
+        PowerLimit(api, device_name=config[CONF_NAME], sensor_name="On-Grid Power", sensor_id="max_output_power"),
+    ], True)
 
     cloud_coordinator = config.get(CLOUD_COORDINATOR)
     if cloud_coordinator is not None:
-        numbers.extend([
+        # No update_before_add here: these already have the coordinator's
+        # data. update_before_add=True is not fire-and-forget -- entity_
+        # platform awaits it, so it would put an undeadlined cloud GET
+        # (cloud.py's no-deadline exemption is scoped to DataUpdateCoordinator
+        # as the caller) on the setup path, on top of the refresh __init__.py
+        # already did and deliberately capped at 20 s.
+        add_entities([
             EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMin", "SOC Minimum"),
             EzhiCloudSocNumber(cloud_coordinator, config[CONF_NAME], "socMax", "SOC Maximum"),
         ])
-
-    add_entities(numbers, True)
 
 
 class PowerLimit(NumberEntity):

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -96,6 +96,19 @@ class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
                     "Physically disconnect the battery first, or make this change "
                     "from the APsystems app if you know what you are doing."
                 )
+            if no_battery != "1":
+                # Absent or unparsable, so we cannot tell. This used to fall
+                # through and allow the switch -- failing open on the one
+                # question the guard exists to answer. Refusing costs nothing
+                # when the field is there (every firmware seen reports it), and
+                # the message says exactly where to go when it is not.
+                raise HomeAssistantError(
+                    "refusing to switch to 'No Battery' mode: the cloud config "
+                    f"does not say whether a battery is connected (noBattery="
+                    f"{no_battery!r}). Switching blind is how the 'battery "
+                    "connection conflict' happens. Use the APsystems app, which "
+                    "asks the device directly."
+                )
         try:
             async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
                 # No config argument: the client re-reads the live config

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -11,7 +11,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .cloud import EzhiCloudError, wire_str
-from .const import CLOUD_COORDINATOR, DOMAIN, SYSTEM_MODE_OPTIONS
+from .const import (
+    CLOUD_COORDINATOR,
+    DOMAIN,
+    SYSTEM_MODE_NO_BATTERY,
+    SYSTEM_MODE_OPTIONS,
+)
 from .entity import CLOUD_WRITE_TIMEOUT_S, EzhiCloudEntity
 
 _VALUE_TO_OPTION = {value: name for name, value in SYSTEM_MODE_OPTIONS.items()}
@@ -34,9 +39,13 @@ async def async_setup_entry(
 class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
     """The inverter's system mode.
 
-    Only the two verified modes are offered. The API also accepts a mode 3, but
-    what it actually does is unconfirmed — and this select writes to real
-    hardware, so it does not guess.
+    Five of the six modes are offered; see const.SYSTEM_MODE_OPTIONS for why
+    the AC-coupled variant is not.
+
+    Switching to Local mode is what enables the local HTTP API this integration
+    reads from. Leaving it does not break the cloud entities, but it does stop
+    the local sensors updating -- that is a property of the device, not of this
+    code.
     """
 
     _attr_icon = "mdi:home-lightning-bolt"
@@ -44,6 +53,21 @@ class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
 
     def __init__(self, coordinator, device_name: str):
         super().__init__(coordinator, device_name, "system_mode", "System Mode")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        return {
+            "no_battery_mode_warning": (
+                "'No Battery' is for inverters running without a battery attached. "
+                "Selecting it while a battery is connected is the 'battery connection "
+                "conflict' the vendor app warns about; this entity refuses the write "
+                "while the cloud still reports a battery."
+            ),
+            "local_mode_note": (
+                "'Local' is the mode that enables the local HTTP API. Switching away "
+                "from it stops this integration's local sensors updating."
+            ),
+        }
 
     @property
     def current_option(self) -> str | None:
@@ -57,6 +81,21 @@ class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
         return _VALUE_TO_OPTION.get(wire_str(raw))
 
     async def async_select_option(self, option: str) -> None:
+        if SYSTEM_MODE_OPTIONS[option] == SYSTEM_MODE_NO_BATTERY:
+            # A guard, not a label. The vendor app raises "battery connection
+            # conflict" for exactly this and tells the user to disconnect the
+            # battery first. noBattery is the device's own report, so this
+            # lifts by itself once a battery really is gone -- no override
+            # switch to leave lying around, and nothing to remember to undo.
+            no_battery = wire_str((self.coordinator.data or {}).get("noBattery", ""))
+            if no_battery == "0":
+                raise HomeAssistantError(
+                    "refusing to switch to 'No Battery' mode: the inverter still "
+                    "reports a battery connected (noBattery=0). That combination is "
+                    "the 'battery connection conflict' the vendor app warns about. "
+                    "Physically disconnect the battery first, or make this change "
+                    "from the APsystems app if you know what you are doing."
+                )
         try:
             async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
                 # No config argument: the client re-reads the live config

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .cloud import EzhiCloudError
+from .cloud import EzhiCloudError, wire_str
 from .const import CLOUD_COORDINATOR, DOMAIN, SYSTEM_MODE_OPTIONS
 from .entity import EzhiCloudEntity
 
@@ -46,8 +46,13 @@ class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         raw = (self.coordinator.data or {}).get("systemMode")
-        # None for an unmapped mode (e.g. 3) rather than a wrong label.
-        return _VALUE_TO_OPTION.get(str(raw)) if raw is not None else None
+        if raw is None:
+            return None
+        # wire_str, not a bare str(): build_system_mode_params normalises the
+        # same payload's fields with wire_str for writes (str(2.0) == "2.0",
+        # not the "2" this key table uses). None for an unmapped mode (e.g. 3)
+        # rather than a wrong label.
+        return _VALUE_TO_OPTION.get(wire_str(raw))
 
     async def async_select_option(self, option: str) -> None:
         try:

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -1,0 +1,74 @@
+"""Select platform for the APsystems EZHI integration (cloud-backed)."""
+from __future__ import annotations
+
+from homeassistant import config_entries
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .cloud import EzhiCloudError
+from .const import CLOUD_COORDINATOR, DOMAIN, SYSTEM_MODE_OPTIONS
+
+_VALUE_TO_OPTION = {value: name for name, value in SYSTEM_MODE_OPTIONS.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the select platform."""
+    config = hass.data[DOMAIN][config_entry.entry_id]
+    cloud_coordinator = config.get(CLOUD_COORDINATOR)
+    if cloud_coordinator is None:
+        return
+
+    add_entities([EzhiCloudSystemModeSelect(cloud_coordinator, config[CONF_NAME])])
+
+
+class EzhiCloudSystemModeSelect(CoordinatorEntity, SelectEntity):
+    """The inverter's system mode.
+
+    Only the two verified modes are offered. The API also accepts a mode 3, but
+    what it actually does is unconfirmed — and this select writes to real
+    hardware, so it does not guess.
+    """
+
+    _attr_icon = "mdi:home-lightning-bolt"
+    _attr_options = list(SYSTEM_MODE_OPTIONS)
+
+    def __init__(self, coordinator, device_name: str):
+        super().__init__(coordinator)
+        self._device_name = device_name
+        self._attr_name = f"APsystems {device_name} System Mode"
+        self._attr_unique_id = f"apsystems_{device_name}_cloud_system_mode"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_name)},
+            name=self._device_name,
+            manufacturer="APsystems",
+            model="EZHI",
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        raw = (self.coordinator.data or {}).get("systemMode")
+        # None for an unmapped mode (e.g. 3) rather than a wrong label.
+        return _VALUE_TO_OPTION.get(str(raw)) if raw is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        try:
+            # No config argument: the client re-reads the live config itself, so
+            # a mode switch cannot write back a minute-old EPS/ECO.
+            await self.coordinator.api.async_set_system_mode(
+                systemMode=SYSTEM_MODE_OPTIONS[option]
+            )
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -1,6 +1,8 @@
 """Select platform for the APsystems EZHI integration (cloud-backed)."""
 from __future__ import annotations
 
+import asyncio
+
 from homeassistant import config_entries
 from homeassistant.components.select import SelectEntity
 from homeassistant.const import CONF_NAME
@@ -10,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .cloud import EzhiCloudError, wire_str
 from .const import CLOUD_COORDINATOR, DOMAIN, SYSTEM_MODE_OPTIONS
-from .entity import EzhiCloudEntity
+from .entity import CLOUD_WRITE_TIMEOUT_S, EzhiCloudEntity
 
 _VALUE_TO_OPTION = {value: name for name, value in SYSTEM_MODE_OPTIONS.items()}
 
@@ -56,11 +58,19 @@ class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         try:
-            # No config argument: the client re-reads the live config itself, so
-            # a mode switch cannot write back a minute-old EPS/ECO.
-            await self.coordinator.api.async_set_system_mode(
-                systemMode=SYSTEM_MODE_OPTIONS[option]
-            )
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                # No config argument: the client re-reads the live config
+                # itself, so a mode switch cannot write back a minute-old
+                # EPS/ECO. That re-read is a GET before the POST, so the
+                # unguarded worst case here is roughly double switch.py's.
+                await self.coordinator.api.async_set_system_mode(
+                    systemMode=SYSTEM_MODE_OPTIONS[option]
+                )
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                "-- the system mode change may or may not have been applied"
+            ) from err
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err
         await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/select.py
+++ b/custom_components/apsystems_ezhi_local/select.py
@@ -6,12 +6,11 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .cloud import EzhiCloudError
 from .const import CLOUD_COORDINATOR, DOMAIN, SYSTEM_MODE_OPTIONS
+from .entity import EzhiCloudEntity
 
 _VALUE_TO_OPTION = {value: name for name, value in SYSTEM_MODE_OPTIONS.items()}
 
@@ -30,7 +29,7 @@ async def async_setup_entry(
     add_entities([EzhiCloudSystemModeSelect(cloud_coordinator, config[CONF_NAME])])
 
 
-class EzhiCloudSystemModeSelect(CoordinatorEntity, SelectEntity):
+class EzhiCloudSystemModeSelect(EzhiCloudEntity, SelectEntity):
     """The inverter's system mode.
 
     Only the two verified modes are offered. The API also accepts a mode 3, but
@@ -42,19 +41,7 @@ class EzhiCloudSystemModeSelect(CoordinatorEntity, SelectEntity):
     _attr_options = list(SYSTEM_MODE_OPTIONS)
 
     def __init__(self, coordinator, device_name: str):
-        super().__init__(coordinator)
-        self._device_name = device_name
-        self._attr_name = f"APsystems {device_name} System Mode"
-        self._attr_unique_id = f"apsystems_{device_name}_cloud_system_mode"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_name)},
-            name=self._device_name,
-            manufacturer="APsystems",
-            model="EZHI",
-        )
+        super().__init__(coordinator, device_name, "system_mode", "System Mode")
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/apsystems_ezhi_local/sensor.py
+++ b/custom_components/apsystems_ezhi_local/sensor.py
@@ -19,7 +19,9 @@ from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import ApSystemsDataCoordinator
-from .const import DOMAIN
+from .const import CLOUD_COORDINATOR, DOMAIN
+from .cloud import HIGH_POWER_LIMIT, STANDARD_POWER_LIMIT
+from .entity import EzhiCloudEntity
 from .api import ReturnDeviceInfo
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -168,6 +170,55 @@ async def async_setup_entry(
     ]
 
     add_entities(sensors)
+
+    cloud_coordinator = config.get(CLOUD_COORDINATOR)
+    if cloud_coordinator is not None:
+        add_entities([EzhiCloudPowerLimitSensor(cloud_coordinator, config[CONF_NAME])])
+
+
+class EzhiCloudPowerLimitSensor(EzhiCloudEntity, SensorEntity):
+    """The output power ceiling -- read-only on purpose.
+
+    This is the app's "high power mode": 800 W standard, 1200 W high. It is a
+    sensor and not a number or a switch because raising it carries the vendor's
+    disclaimer about exceeding regulatory feed-in limits, and Home Assistant
+    cannot put a confirmation in front of an entity. Changing it goes through
+    the apsystems_ezhi_local.set_high_power_mode service, which requires an
+    explicit acknowledgement.
+
+    Not to be confused with the local "On-Grid Power" number, which is the
+    momentary setpoint (-1200..1200 W), not a ceiling.
+    """
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(self, coordinator, device_name: str):
+        super().__init__(coordinator, device_name, "power_limit_state", "Power Limit")
+
+    @property
+    def native_value(self) -> int | None:
+        raw = (self.coordinator.data or {}).get("powerLimit")
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        value = self.native_value
+        return {
+            "high_power_mode": {
+                HIGH_POWER_LIMIT: "on",
+                STANDARD_POWER_LIMIT: "off",
+            }.get(value, "unknown"),
+            "change_with": (
+                "action: apsystems_ezhi_local.set_high_power_mode -- read-only "
+                "here because enabling 1200 W may exceed the regulatory limit "
+                "for your grid connection and needs an explicit acknowledgement."
+            ),
+        }
 
 
 class BaseSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/apsystems_ezhi_local/services.yaml
+++ b/custom_components/apsystems_ezhi_local/services.yaml
@@ -7,3 +7,31 @@ set_power:
     power:
       description: Power limit in watts
       example: 600
+
+set_high_power_mode:
+  name: Set high power mode
+  description: >-
+    Switch the EZHI output ceiling between 800 W (standard) and 1200 W (high
+    power). DISCLAIMER, quoted from the APsystems app: enabling high power mode
+    "may cause the device output to exceed regulatory limits for grid
+    connection. Any legal risks, safety incidents, or other consequences
+    arising therefrom shall be solely your responsibility." This is a service
+    rather than a switch entity so that enabling it cannot happen with one
+    stray tap on a dashboard.
+  fields:
+    enable:
+      name: Enable high power mode
+      description: On sets the ceiling to 1200 W, off returns it to 800 W.
+      required: true
+      selector:
+        boolean:
+    acknowledge_regulatory_risk:
+      name: I accept the regulatory risk
+      description: >-
+        Required when enabling. Confirms you have read the disclaimer above and
+        accept responsibility for operating above the standard 800 W ceiling.
+        Not needed when switching back down to 800 W.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/apsystems_ezhi_local/services.yaml
+++ b/custom_components/apsystems_ezhi_local/services.yaml
@@ -1,12 +1,29 @@
 set_power:
-  description: Set the power limit of the APsystems EZHI inverter
+  name: Set output power
+  description: >-
+    Set the grid setpoint of the APsystems EZHI inverter. Negative discharges
+    to the grid, positive charges from it.
   fields:
     device_id:
-      description: Device ID of the inverter
-      example: apsystems_ezhi
+      name: Device
+      description: >-
+        Which inverter. Optional when only one is set up; required when several
+        are, because this call will not pick one for you.
+      required: false
+      selector:
+        device:
+          integration: apsystems_ezhi_local
     power:
-      description: Power limit in watts
+      name: Power
+      description: Power in watts
+      required: true
       example: 600
+      selector:
+        number:
+          min: -1200
+          max: 1200
+          step: 10
+          unit_of_measurement: W
 
 set_high_power_mode:
   name: Set high power mode
@@ -19,6 +36,16 @@ set_high_power_mode:
     rather than a switch entity so that enabling it cannot happen with one
     stray tap on a dashboard.
   fields:
+    device_id:
+      name: Device
+      description: >-
+        Which inverter. Optional when only one is set up; required when several
+        are -- raising a regulatory ceiling on a device you did not mean is
+        exactly what this field prevents.
+      required: false
+      selector:
+        device:
+          integration: apsystems_ezhi_local
     enable:
       name: Enable high power mode
       description: On sets the ceiling to 1200 W, off returns it to 800 W.

--- a/custom_components/apsystems_ezhi_local/strings.json
+++ b/custom_components/apsystems_ezhi_local/strings.json
@@ -44,6 +44,7 @@
           "cloud_refresh_token": "Cloud refresh token (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
+        "description": "Polling intervals for the local API, and the optional cloud credentials.",
         "title": "APsystems EZHI options"
       }
     }

--- a/custom_components/apsystems_ezhi_local/strings.json
+++ b/custom_components/apsystems_ezhi_local/strings.json
@@ -42,18 +42,18 @@
           "scan_interval_alarm": "Alarm data interval (seconds)",
           "cloud_access_token": "Cloud access token (optional)",
           "cloud_refresh_token": "Cloud refresh token (optional)",
-          "cloud_username": "EMA account e-mail (optional)",
+          "cloud_username": "EMA account username (optional)",
           "cloud_password": "EMA account password (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
-        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA e-mail and password to fetch the tokens automatically — they are used once and never stored.",
+        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA username and password to fetch the tokens automatically — the username, not the e-mail address. They are used once and never stored.",
         "title": "APsystems EZHI options"
       }
     },
     "error": {
-      "invalid_auth": "The EMA cloud rejected that e-mail and password.",
+      "invalid_auth": "The EMA cloud rejected that username and password. Note that it wants the account username, not the e-mail address.",
       "cannot_connect": "Could not reach the EMA cloud. Try again in a moment.",
-      "incomplete_credentials": "Enter both the e-mail address and the password, or neither."
+      "incomplete_credentials": "Enter both the username and the password, or neither."
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/strings.json
+++ b/custom_components/apsystems_ezhi_local/strings.json
@@ -6,17 +6,46 @@
           "ip_address": "IP Address",
           "name": "Name",
           "check": "Check connection during setup",
-          "update_interval": "Update interval in seconds"
+          "update_interval": "Update interval in seconds",
+          "scan_interval_output": "Output data interval (seconds)",
+          "scan_interval_alarm": "Alarm data interval (seconds)",
+          "cloud_access_token": "Cloud access token (optional)",
+          "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
-        "description": "Enter the local IP address of your APsystems EZHI inverter.",
+        "description": "Enter the local IP address of your APsystems EZHI inverter. The cloud fields are optional and only needed for the remote control entities (on/off, system mode, SOC limits) — see the README on how to obtain the tokens.",
         "title": "APsystems EZHI"
+      },
+      "reauth_confirm": {
+        "data": {
+          "cloud_access_token": "Cloud access token",
+          "cloud_refresh_token": "Cloud refresh token"
+        },
+        "description": "The stored cloud refresh token is no longer valid. Capture a new pair from the AP EasyPower app and enter it here.",
+        "title": "Reconnect APsystems cloud"
       }
     },
     "error": {
-      "connection_refused": "Unable to connect to the inverter. Check the IP address."
+      "connection_refused": "Unable to connect to the inverter. Check the IP address.",
+      "cloud_auth_failed": "The cloud rejected these credentials. Check that you copied both tokens correctly."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Cloud credentials updated"
+    }
+  },
+  "options": {
+    "step": {
+      "device_options": {
+        "data": {
+          "scan_interval_output": "Output data interval (seconds)",
+          "scan_interval_alarm": "Alarm data interval (seconds)",
+          "cloud_access_token": "Cloud access token (optional)",
+          "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_scan_interval": "Cloud poll interval (seconds)"
+        },
+        "title": "APsystems EZHI options"
+      }
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/strings.json
+++ b/custom_components/apsystems_ezhi_local/strings.json
@@ -42,11 +42,18 @@
           "scan_interval_alarm": "Alarm data interval (seconds)",
           "cloud_access_token": "Cloud access token (optional)",
           "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_username": "EMA account e-mail (optional)",
+          "cloud_password": "EMA account password (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
-        "description": "Polling intervals for the local API, and the optional cloud credentials.",
+        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA e-mail and password to fetch the tokens automatically — they are used once and never stored.",
         "title": "APsystems EZHI options"
       }
+    },
+    "error": {
+      "invalid_auth": "The EMA cloud rejected that e-mail and password.",
+      "cannot_connect": "Could not reach the EMA cloud. Try again in a moment.",
+      "incomplete_credentials": "Enter both the e-mail address and the password, or neither."
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -1,93 +1,61 @@
-"""Switch platform for APsystems EZHI local API integration."""
+"""Switch platform for the APsystems EZHI integration.
+
+The only switch is cloud-backed: on/off does not exist in the local API.
+"""
 from __future__ import annotations
 
 from typing import Any
 
 from homeassistant import config_entries
-from homeassistant.components.switch import SwitchEntity, PLATFORM_SCHEMA
-from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-import voluptuous as vol
-
-from .const import DOMAIN
-from . import ApSystemsDataCoordinator
-
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_IP_ADDRESS): cv.string,
-    vol.Optional(CONF_NAME, default="ezhi"): cv.string,
-})
+from .cloud import EzhiCloudError
+from .const import CLOUD_COORDINATOR, DOMAIN
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: config_entries.ConfigEntry,
     add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None
 ) -> None:
     """Set up the switch platform."""
     config = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = config["COORDINATOR"]
-    
-    # Currently, there are no specific switches in the API documentation
-    # This is a placeholder for future functionality
-    # If you discover additional API endpoints for switching features, add them here
-    
-    # Example of how to add a switch if you have one:
-    # add_entities([
-    #    EZHIModeSwitchEntity(
-    #        coordinator,
-    #        device_name=config[CONF_NAME],
-    #        switch_name="Local Mode",
-    #        switch_id="local_mode",
-    #    )
-    # ])
-    
-    # Since we don't have any actual switches to add yet, we'll just return
-    return
+    cloud_coordinator = config.get(CLOUD_COORDINATOR)
+    if cloud_coordinator is None:
+        # No cloud credentials configured — local-only setup, nothing to add.
+        return
+
+    add_entities([EzhiCloudOnOffSwitch(cloud_coordinator, config[CONF_NAME])])
 
 
-class BaseEZHISwitchEntity(CoordinatorEntity, SwitchEntity):
-    """Base switch entity for APsystems EZHI."""
-    
-    def __init__(
-        self,
-        coordinator: ApSystemsDataCoordinator,
-        device_name: str,
-        switch_name: str,
-        switch_id: str,
-    ):
-        """Initialize the switch."""
+class EzhiCloudOnOffSwitch(CoordinatorEntity, SwitchEntity):
+    """Turns the inverter on and off through the EMA cloud.
+
+    Two things about this switch are not obvious:
+
+    1. The wire format is inverted — the cloud field ``onOff`` reads "0" while
+       the inverter is running.
+    2. Switching it off is a one-way trip from Home Assistant. Once the inverter
+       is down it drops off MQTT and the cloud can no longer reach it, so turning
+       it back on needs PV/DC input or a 3 s press on the battery button.
+    """
+
+    _attr_icon = "mdi:power"
+
+    def __init__(self, coordinator, device_name: str):
         super().__init__(coordinator)
         self._device_name = device_name
-        self._switch_name = switch_name
-        self._switch_id = switch_id
-        self._is_on = False
-    
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return f"{self._device_name} {self._switch_name}"
-    
-    @property
-    def is_on(self) -> bool:
-        """Return True if entity is on."""
-        return self._is_on
-    
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID of this switch."""
-        return f"apsystems_{self._device_name}_{self._switch_id}"
-    
+        self._attr_name = f"APsystems {device_name} Inverter On"
+        self._attr_unique_id = f"apsystems_{device_name}_cloud_on_off"
+
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device information."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._device_name)},
             name=self._device_name,
@@ -95,24 +63,32 @@ class BaseEZHISwitchEntity(CoordinatorEntity, SwitchEntity):
             model="EZHI",
         )
 
-# Example switch implementation for future use
-# class EZHIModeSwitchEntity(BaseEZHISwitchEntity):
-#     """Switch entity for controlling a specific mode."""
-#
-#     async def async_turn_on(self, **kwargs: Any) -> None:
-#         """Turn the entity on."""
-#         try:
-#             # Call the API to turn on the feature
-#             # await self.coordinator.api.turn_on_feature()
-#             self._is_on = True
-#         except Exception as e:
-#             self.coordinator.logger.error("Could not turn on feature: %s", e)
-#
-#     async def async_turn_off(self, **kwargs: Any) -> None:
-#         """Turn the entity off."""
-#         try:
-#             # Call the API to turn off the feature
-#             # await self.coordinator.api.turn_off_feature()
-#             self._is_on = False
-#         except Exception as e:
-#             self.coordinator.logger.error("Could not turn off feature: %s", e)
+    @property
+    def is_on(self) -> bool | None:
+        raw = (self.coordinator.data or {}).get("onOff")
+        if raw is None:
+            return None
+        return str(raw) == "0"  # "0" is running, "1" is off
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "remote_turn_on_limitation": (
+                "Only works while the inverter is still online. Once off, wake it "
+                "with PV/DC input or a 3 s press on the battery button."
+            )
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._async_set(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._async_set(False)
+
+    async def _async_set(self, on: bool) -> None:
+        try:
+            await self.coordinator.api.async_set_on_off(on)
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        # Re-read rather than trusting the write: confirm against the device.
+        await self.coordinator.async_request_refresh()

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -1,6 +1,8 @@
 """Switch platform for the APsystems EZHI integration.
 
-The only switch is cloud-backed: on/off does not exist in the local API.
+Every switch here is cloud-backed -- none of on/off, backup power (EPS) or
+ECO exists in the local API. That is the whole reason the cloud layer was
+built.
 """
 from __future__ import annotations
 
@@ -14,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .cloud import EzhiCloudError, is_running
+from .cloud import EzhiCloudError, is_running, wire_str
 from .const import CLOUD_COORDINATOR, DOMAIN
 from .entity import CLOUD_WRITE_TIMEOUT_S, EzhiCloudEntity
 
@@ -31,7 +33,11 @@ async def async_setup_entry(
         # No cloud credentials configured — local-only setup, nothing to add.
         return
 
-    add_entities([EzhiCloudOnOffSwitch(cloud_coordinator, config[CONF_NAME])])
+    add_entities([
+        EzhiCloudOnOffSwitch(cloud_coordinator, config[CONF_NAME]),
+        EzhiCloudBackupPowerSwitch(cloud_coordinator, config[CONF_NAME]),
+        EzhiCloudEcoSwitch(cloud_coordinator, config[CONF_NAME]),
+    ])
 
 
 class EzhiCloudOnOffSwitch(EzhiCloudEntity, SwitchEntity):
@@ -98,3 +104,114 @@ class EzhiCloudOnOffSwitch(EzhiCloudEntity, SwitchEntity):
             raise HomeAssistantError(str(err)) from err
         # Re-read rather than trusting the write: confirm against the device.
         await self.coordinator.async_request_refresh()
+
+
+class _EzhiCloudSystemModeSwitch(EzhiCloudEntity, SwitchEntity):
+    """A boolean field inside the systemMode config blob.
+
+    Not assumed_state, unlike the on/off switch above: these are reversible
+    from Home Assistant, so a plain toggle is right and there is no reason to
+    make them two deliberate buttons.
+    """
+
+    _key: str
+
+    @property
+    def is_on(self) -> bool | None:
+        raw = (self.coordinator.data or {}).get(self._key)
+        if raw is None:
+            return None
+        # Same normalisation the write path uses, so "1"/1/1.0/True all agree.
+        return wire_str(raw) == "1"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._async_write(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._async_write(False)
+
+    async def _async_write(self, on: bool) -> None:
+        raise NotImplementedError
+
+    async def _async_guarded(self, coro_factory, what: str) -> None:
+        try:
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                # The client re-reads the live config before posting, so this
+                # is a GET plus a POST -- roughly double a single-call write.
+                await coro_factory()
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                f"-- the {what} change may or may not have been applied"
+            ) from err
+        except EzhiCloudError as err:
+            raise HomeAssistantError(str(err)) from err
+        await self.coordinator.async_request_refresh()
+
+
+class EzhiCloudBackupPowerSwitch(_EzhiCloudSystemModeSwitch):
+    """EPS -- backup / emergency power on the off-grid side.
+
+    This is the control the whole cloud layer was built for: it is not in the
+    local API at all.
+
+    Turning it on also clears ECO, because the firmware treats the two as
+    mutually exclusive. That pairing lives in cloud.async_set_backup_power so
+    it has one home and a test; this file has no HA test harness.
+
+    The vendor app only shows this switch in modes 1, 2 and 5 -- in Local mode
+    it is hidden, though the field keeps its value (live: EPS=1 while in mode
+    4). Whether a write lands in Local mode is unverified, so this entity does
+    not claim it did: the post-write re-read is the confirmation.
+    """
+
+    _attr_icon = "mdi:home-battery"
+    _key = "EPS"
+
+    def __init__(self, coordinator, device_name: str):
+        super().__init__(coordinator, device_name, "eps", "Backup Power")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        return {
+            "mutually_exclusive_with": "ECO -- enabling backup power disables ECO",
+            "vendor_app_visibility": (
+                "Shown only in Balcony Storage, Portable and Balcony Storage AC "
+                "modes. In Local mode the value persists but is not editable in "
+                "the app; a write from here may be a no-op."
+            ),
+        }
+
+    async def _async_write(self, on: bool) -> None:
+        await self._async_guarded(
+            lambda: self.coordinator.api.async_set_backup_power(on), "backup power"
+        )
+
+
+class EzhiCloudEcoSwitch(_EzhiCloudSystemModeSwitch):
+    """ECO -- shuts the off-grid side down after an hour with no load.
+
+    Measured, so nobody re-derives it: ECO does NOT reduce standby draw. An
+    A/B test found the same ~17 W either way. It only powers down the off-grid
+    output when nothing is drawing from it.
+    """
+
+    _attr_icon = "mdi:leaf"
+    _key = "ECO"
+
+    def __init__(self, coordinator, device_name: str):
+        super().__init__(coordinator, device_name, "eco", "ECO Mode")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        return {
+            "mutually_exclusive_with": "EPS -- enabling ECO disables backup power",
+            "does_not_reduce_standby": (
+                "Measured 2026-07-31: battery draw was ~17 W with and without ECO."
+            ),
+        }
+
+    async def _async_write(self, on: bool) -> None:
+        await self._async_guarded(
+            lambda: self.coordinator.api.async_set_eco(on), "ECO mode"
+        )

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -11,12 +11,11 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .cloud import EzhiCloudError, is_running
 from .const import CLOUD_COORDINATOR, DOMAIN
+from .entity import EzhiCloudEntity
 
 
 async def async_setup_entry(
@@ -34,7 +33,7 @@ async def async_setup_entry(
     add_entities([EzhiCloudOnOffSwitch(cloud_coordinator, config[CONF_NAME])])
 
 
-class EzhiCloudOnOffSwitch(CoordinatorEntity, SwitchEntity):
+class EzhiCloudOnOffSwitch(EzhiCloudEntity, SwitchEntity):
     """Turns the inverter on and off through the EMA cloud.
 
     Two things about this switch are not obvious:
@@ -61,19 +60,7 @@ class EzhiCloudOnOffSwitch(CoordinatorEntity, SwitchEntity):
     _attr_assumed_state = True
 
     def __init__(self, coordinator, device_name: str):
-        super().__init__(coordinator)
-        self._device_name = device_name
-        self._attr_name = f"APsystems {device_name} Inverter On"
-        self._attr_unique_id = f"apsystems_{device_name}_cloud_on_off"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_name)},
-            name=self._device_name,
-            manufacturer="APsystems",
-            model="EZHI",
-        )
+        super().__init__(coordinator, device_name, "on_off", "Inverter On")
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -159,10 +159,10 @@ class EzhiCloudBackupPowerSwitch(_EzhiCloudSystemModeSwitch):
     mutually exclusive. That pairing lives in cloud.async_set_backup_power so
     it has one home and a test; this file has no HA test harness.
 
-    The vendor app only shows this switch in modes 1, 2 and 5 -- in Local mode
-    it is hidden, though the field keeps its value (live: EPS=1 while in mode
-    4). Whether a write lands in Local mode is unverified, so this entity does
-    not claim it did: the post-write re-read is the confirmation.
+    The vendor app hides this switch in Local mode, but the write works there
+    anyway -- measured 2026-08-01 from Home Assistant, EPS 1 -> 0 -> 1 while
+    the device stayed in mode 4, no other field touched. A UI decision in the
+    app, not an API restriction.
     """
 
     _attr_icon = "mdi:home-battery"
@@ -176,9 +176,8 @@ class EzhiCloudBackupPowerSwitch(_EzhiCloudSystemModeSwitch):
         return {
             "mutually_exclusive_with": "ECO -- enabling backup power disables ECO",
             "vendor_app_visibility": (
-                "Shown only in Balcony Storage, Portable and Balcony Storage AC "
-                "modes. In Local mode the value persists but is not editable in "
-                "the app; a write from here may be a no-op."
+                "The vendor app hides this switch in Local mode. Writing it from "
+                "here works there regardless -- verified 2026-08-01."
             ),
         }
 

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -4,6 +4,7 @@ The only switch is cloud-backed: on/off does not exist in the local API.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from homeassistant import config_entries
@@ -15,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .cloud import EzhiCloudError, is_running
 from .const import CLOUD_COORDINATOR, DOMAIN
-from .entity import EzhiCloudEntity
+from .entity import CLOUD_WRITE_TIMEOUT_S, EzhiCloudEntity
 
 
 async def async_setup_entry(
@@ -86,7 +87,13 @@ class EzhiCloudOnOffSwitch(EzhiCloudEntity, SwitchEntity):
 
     async def _async_set(self, on: bool) -> None:
         try:
-            await self.coordinator.api.async_set_on_off(on)
+            async with asyncio.timeout(CLOUD_WRITE_TIMEOUT_S):
+                await self.coordinator.api.async_set_on_off(on)
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"the EZHI cloud did not answer within {CLOUD_WRITE_TIMEOUT_S} s "
+                "-- the on/off command may or may not have been applied"
+            ) from err
         except EzhiCloudError as err:
             raise HomeAssistantError(str(err)) from err
         # Re-read rather than trusting the write: confirm against the device.

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -47,6 +47,18 @@ class EzhiCloudOnOffSwitch(CoordinatorEntity, SwitchEntity):
     """
 
     _attr_icon = "mdi:power"
+    # Not literally true -- we do poll real state -- but taken deliberately
+    # for two practical reasons, not semantic purity:
+    #   1. Renders as two separate buttons instead of one toggle. Turning
+    #      this inverter off cannot be undone from HA, so it should take a
+    #      deliberate press, not an accidental brush of a toggle.
+    #   2. Removes a snap-back hazard. The cloud coordinator has
+    #      always_update=False, so an unchanged post-write GET fires no
+    #      listener and this entity gets no state write after the service
+    #      call. A toggle's optimistic flip then has nothing confirming it,
+    #      reverts, reads as "it didn't work" -- and risks a second write to
+    #      a hybrid inverter. Do not "fix" this back to False.
+    _attr_assumed_state = True
 
     def __init__(self, coordinator, device_name: str):
         super().__init__(coordinator)

--- a/custom_components/apsystems_ezhi_local/switch.py
+++ b/custom_components/apsystems_ezhi_local/switch.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .cloud import EzhiCloudError
+from .cloud import EzhiCloudError, is_running
 from .const import CLOUD_COORDINATOR, DOMAIN
 
 
@@ -65,10 +65,10 @@ class EzhiCloudOnOffSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        raw = (self.coordinator.data or {}).get("onOff")
-        if raw is None:
-            return None
-        return str(raw) == "0"  # "0" is running, "1" is off
+        # is_running lives in cloud.py, beside async_set_on_off, so the one
+        # piece of inverted-wire knowledge has a single home -- and one this
+        # entity file cannot itself have a test for (no HA test harness here).
+        return is_running((self.coordinator.data or {}).get("onOff"))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/apsystems_ezhi_local/translations/de.json
+++ b/custom_components/apsystems_ezhi_local/translations/de.json
@@ -44,6 +44,7 @@
           "cloud_refresh_token": "Cloud-Refresh-Token (optional)",
           "cloud_scan_interval": "Cloud-Abfrageintervall (Sekunden)"
         },
+        "description": "Abrufintervalle für die lokale API und die optionalen Cloud-Zugangsdaten.",
         "title": "APsystems-EZHI-Optionen"
       }
     }

--- a/custom_components/apsystems_ezhi_local/translations/de.json
+++ b/custom_components/apsystems_ezhi_local/translations/de.json
@@ -2,33 +2,49 @@
   "config": {
     "step": {
       "user": {
-        "title": "APsystems EZHI",
-        "description": "Gib die lokale IP-Adresse deines APsystems EZHI Wechselrichters ein.",
         "data": {
           "ip_address": "IP-Adresse",
           "name": "Name",
-          "check": "Verbindung beim Setup prüfen",
-          "scan_interval_output": "Abrufintervall Leistungsdaten (Sek.)",
-          "scan_interval_alarm": "Abrufintervall Alarme & Geräteinfo (Sek.)"
-        }
+          "check": "Verbindung bei der Einrichtung prüfen",
+          "update_interval": "Aktualisierungsintervall in Sekunden",
+          "scan_interval_output": "Intervall Ausgangsdaten (Sekunden)",
+          "scan_interval_alarm": "Intervall Alarmdaten (Sekunden)",
+          "cloud_access_token": "Cloud-Access-Token (optional)",
+          "cloud_refresh_token": "Cloud-Refresh-Token (optional)",
+          "cloud_scan_interval": "Cloud-Abfrageintervall (Sekunden)"
+        },
+        "description": "Gib die lokale IP-Adresse deines APsystems-EZHI-Wechselrichters ein. Die Cloud-Felder sind optional und nur für die Fernsteuerung nötig (An/Aus, Systemmodus, SOC-Grenzen) — wie du an die Tokens kommst, steht in der README.",
+        "title": "APsystems EZHI"
+      },
+      "reauth_confirm": {
+        "data": {
+          "cloud_access_token": "Cloud-Access-Token",
+          "cloud_refresh_token": "Cloud-Refresh-Token"
+        },
+        "description": "Das gespeicherte Cloud-Refresh-Token ist nicht mehr gültig. Fang ein neues Paar aus der AP-EasyPower-App ab und trag es hier ein.",
+        "title": "APsystems-Cloud neu verbinden"
       }
     },
     "error": {
-      "connection_refused": "Verbindung fehlgeschlagen. Prüfe die IP-Adresse."
+      "connection_refused": "Verbindung zum Wechselrichter nicht möglich. Prüfe die IP-Adresse.",
+      "cloud_auth_failed": "Die Cloud hat diese Zugangsdaten abgelehnt. Prüfe, ob du beide Tokens vollständig kopiert hast."
     },
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+      "already_configured": "Gerät ist bereits eingerichtet",
+      "reauth_successful": "Cloud-Zugangsdaten aktualisiert"
     }
   },
   "options": {
     "step": {
       "device_options": {
-        "title": "Geräteoptionen",
-        "description": "Konfiguriere die Abrufintervalle für die API-Abfragen",
         "data": {
-          "scan_interval_output": "Leistungsdaten Intervall (Sek.)",
-          "scan_interval_alarm": "Alarme & Geräteinfo Intervall (Sek.)"
-        }
+          "scan_interval_output": "Intervall Ausgangsdaten (Sekunden)",
+          "scan_interval_alarm": "Intervall Alarmdaten (Sekunden)",
+          "cloud_access_token": "Cloud-Access-Token (optional)",
+          "cloud_refresh_token": "Cloud-Refresh-Token (optional)",
+          "cloud_scan_interval": "Cloud-Abfrageintervall (Sekunden)"
+        },
+        "title": "APsystems-EZHI-Optionen"
       }
     }
   }

--- a/custom_components/apsystems_ezhi_local/translations/de.json
+++ b/custom_components/apsystems_ezhi_local/translations/de.json
@@ -42,18 +42,18 @@
           "scan_interval_alarm": "Intervall Alarmdaten (Sekunden)",
           "cloud_access_token": "Cloud-Access-Token (optional)",
           "cloud_refresh_token": "Cloud-Refresh-Token (optional)",
-          "cloud_username": "EMA-Konto-E-Mail (optional)",
+          "cloud_username": "EMA-Konto-Benutzername (optional)",
           "cloud_password": "EMA-Konto-Passwort (optional)",
           "cloud_scan_interval": "Cloud-Abfrageintervall (Sekunden)"
         },
-        "description": "Abfrageintervalle für die lokale API und die optionalen Cloud-Zugangsdaten. E-Mail und Passwort des APsystems-EMA-Kontos eintragen, um die Tokens automatisch zu holen — sie werden einmal benutzt und nicht gespeichert.",
+        "description": "Abfrageintervalle für die lokale API und die optionalen Cloud-Zugangsdaten. Benutzername und Passwort des APsystems-EMA-Kontos eintragen, um die Tokens automatisch zu holen — der Benutzername, nicht die E-Mail-Adresse. Sie werden einmal benutzt und nicht gespeichert.",
         "title": "APsystems-EZHI-Optionen"
       }
     },
     "error": {
-      "invalid_auth": "Die EMA-Cloud hat diese E-Mail und dieses Passwort abgelehnt.",
+      "invalid_auth": "Die EMA-Cloud hat diesen Benutzernamen und dieses Passwort abgelehnt. Beachte: gefragt ist der Konto-Benutzername, nicht die E-Mail-Adresse.",
       "cannot_connect": "Die EMA-Cloud war nicht erreichbar. Bitte gleich noch einmal versuchen.",
-      "incomplete_credentials": "Bitte E-Mail und Passwort zusammen eintragen — oder beides leer lassen."
+      "incomplete_credentials": "Bitte Benutzername und Passwort zusammen eintragen — oder beides leer lassen."
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/translations/de.json
+++ b/custom_components/apsystems_ezhi_local/translations/de.json
@@ -42,11 +42,18 @@
           "scan_interval_alarm": "Intervall Alarmdaten (Sekunden)",
           "cloud_access_token": "Cloud-Access-Token (optional)",
           "cloud_refresh_token": "Cloud-Refresh-Token (optional)",
+          "cloud_username": "EMA-Konto-E-Mail (optional)",
+          "cloud_password": "EMA-Konto-Passwort (optional)",
           "cloud_scan_interval": "Cloud-Abfrageintervall (Sekunden)"
         },
-        "description": "Abrufintervalle für die lokale API und die optionalen Cloud-Zugangsdaten.",
+        "description": "Abfrageintervalle für die lokale API und die optionalen Cloud-Zugangsdaten. E-Mail und Passwort des APsystems-EMA-Kontos eintragen, um die Tokens automatisch zu holen — sie werden einmal benutzt und nicht gespeichert.",
         "title": "APsystems-EZHI-Optionen"
       }
+    },
+    "error": {
+      "invalid_auth": "Die EMA-Cloud hat diese E-Mail und dieses Passwort abgelehnt.",
+      "cannot_connect": "Die EMA-Cloud war nicht erreichbar. Bitte gleich noch einmal versuchen.",
+      "incomplete_credentials": "Bitte E-Mail und Passwort zusammen eintragen — oder beides leer lassen."
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/translations/en.json
+++ b/custom_components/apsystems_ezhi_local/translations/en.json
@@ -44,6 +44,7 @@
           "cloud_refresh_token": "Cloud refresh token (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
+        "description": "Polling intervals for the local API, and the optional cloud credentials.",
         "title": "APsystems EZHI options"
       }
     }

--- a/custom_components/apsystems_ezhi_local/translations/en.json
+++ b/custom_components/apsystems_ezhi_local/translations/en.json
@@ -42,18 +42,18 @@
           "scan_interval_alarm": "Alarm data interval (seconds)",
           "cloud_access_token": "Cloud access token (optional)",
           "cloud_refresh_token": "Cloud refresh token (optional)",
-          "cloud_username": "EMA account e-mail (optional)",
+          "cloud_username": "EMA account username (optional)",
           "cloud_password": "EMA account password (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
-        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA e-mail and password to fetch the tokens automatically — they are used once and never stored.",
+        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA username and password to fetch the tokens automatically — the username, not the e-mail address. They are used once and never stored.",
         "title": "APsystems EZHI options"
       }
     },
     "error": {
-      "invalid_auth": "The EMA cloud rejected that e-mail and password.",
+      "invalid_auth": "The EMA cloud rejected that username and password. Note that it wants the account username, not the e-mail address.",
       "cannot_connect": "Could not reach the EMA cloud. Try again in a moment.",
-      "incomplete_credentials": "Enter both the e-mail address and the password, or neither."
+      "incomplete_credentials": "Enter both the username and the password, or neither."
     }
   }
 }

--- a/custom_components/apsystems_ezhi_local/translations/en.json
+++ b/custom_components/apsystems_ezhi_local/translations/en.json
@@ -2,33 +2,49 @@
   "config": {
     "step": {
       "user": {
-        "title": "APsystems EZHI",
-        "description": "Enter the local IP address of your APsystems EZHI inverter.",
         "data": {
           "ip_address": "IP Address",
           "name": "Name",
           "check": "Check connection during setup",
-          "scan_interval_output": "Scan interval power data (sec)",
-          "scan_interval_alarm": "Scan interval alarms & device info (sec)"
-        }
+          "update_interval": "Update interval in seconds",
+          "scan_interval_output": "Output data interval (seconds)",
+          "scan_interval_alarm": "Alarm data interval (seconds)",
+          "cloud_access_token": "Cloud access token (optional)",
+          "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_scan_interval": "Cloud poll interval (seconds)"
+        },
+        "description": "Enter the local IP address of your APsystems EZHI inverter. The cloud fields are optional and only needed for the remote control entities (on/off, system mode, SOC limits) — see the README on how to obtain the tokens.",
+        "title": "APsystems EZHI"
+      },
+      "reauth_confirm": {
+        "data": {
+          "cloud_access_token": "Cloud access token",
+          "cloud_refresh_token": "Cloud refresh token"
+        },
+        "description": "The stored cloud refresh token is no longer valid. Capture a new pair from the AP EasyPower app and enter it here.",
+        "title": "Reconnect APsystems cloud"
       }
     },
     "error": {
-      "connection_refused": "Unable to connect to the inverter. Check the IP address."
+      "connection_refused": "Unable to connect to the inverter. Check the IP address.",
+      "cloud_auth_failed": "The cloud rejected these credentials. Check that you copied both tokens correctly."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Cloud credentials updated"
     }
   },
   "options": {
     "step": {
       "device_options": {
-        "title": "Device Options",
-        "description": "Configure scan intervals for API polling",
         "data": {
-          "scan_interval_output": "Power data interval (sec)",
-          "scan_interval_alarm": "Alarms & device info interval (sec)"
-        }
+          "scan_interval_output": "Output data interval (seconds)",
+          "scan_interval_alarm": "Alarm data interval (seconds)",
+          "cloud_access_token": "Cloud access token (optional)",
+          "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_scan_interval": "Cloud poll interval (seconds)"
+        },
+        "title": "APsystems EZHI options"
       }
     }
   }

--- a/custom_components/apsystems_ezhi_local/translations/en.json
+++ b/custom_components/apsystems_ezhi_local/translations/en.json
@@ -42,11 +42,18 @@
           "scan_interval_alarm": "Alarm data interval (seconds)",
           "cloud_access_token": "Cloud access token (optional)",
           "cloud_refresh_token": "Cloud refresh token (optional)",
+          "cloud_username": "EMA account e-mail (optional)",
+          "cloud_password": "EMA account password (optional)",
           "cloud_scan_interval": "Cloud poll interval (seconds)"
         },
-        "description": "Polling intervals for the local API, and the optional cloud credentials.",
+        "description": "Polling intervals for the local API, and the optional cloud credentials. Enter your APsystems EMA e-mail and password to fetch the tokens automatically — they are used once and never stored.",
         "title": "APsystems EZHI options"
       }
+    },
+    "error": {
+      "invalid_auth": "The EMA cloud rejected that e-mail and password.",
+      "cannot_connect": "Could not reach the EMA cloud. Try again in a moment.",
+      "incomplete_credentials": "Enter both the e-mail address and the password, or neither."
     }
   }
 }

--- a/examples/dashboard-core.yaml
+++ b/examples/dashboard-core.yaml
@@ -137,6 +137,11 @@ views:
           # Buttons, not entity rows: rows in an entities card ignore
           # tap_action.confirmation, and the 1200 W direction should not be
           # one stray tap away.
+          #
+          # The button carries acknowledge_regulatory_risk: true because the
+          # confirmation dialog below is where the disclaimer is actually read
+          # and accepted. Do not copy that flag into an automation, where
+          # nothing asks anyone anything.
           - type: horizontal-stack
             cards:
               - type: button

--- a/examples/dashboard-core.yaml
+++ b/examples/dashboard-core.yaml
@@ -1,0 +1,240 @@
+# Example dashboard for the APsystems EZHI integration -- built only from
+# cards Home Assistant ships with. No HACS, nothing to install.
+#
+# This is the same dashboard as examples/dashboard.yaml with two swaps:
+#   Mushroom tiles  -> one glance card
+#   fold-entity-row -> a plain (always expanded) entities card
+#
+# HOW TO USE
+#   Settings -> Dashboards -> Add dashboard -> New dashboard from scratch.
+#   Open it, then: pencil icon -> three dots -> Raw configuration editor,
+#   and replace everything there with this file.
+#
+# ENTITY IDS
+#   This file assumes the integration was added with the name "ezhi". If you
+#   used a different name, replace "ezhi" throughout.
+#   Careful: the prefixes are not uniform. The local sensors are
+#   "sensor.ezhi_...", while the cloud entities and the local power number
+#   carry an extra "apsystems_": "switch.apsystems_ezhi_...". The exact ids
+#   for your install are listed on the device page under
+#   Settings -> Devices & Services -> APsystems EZHI -> your device.
+
+views:
+  - title: EZHI
+    path: ezhi
+    type: sections
+    max_columns: 2
+    sections:
+      # ---------------------------------------------------------------- now
+      - type: grid
+        cards:
+          - type: heading
+            heading: Now
+            heading_style: title
+            icon: mdi:flash
+          - type: glance
+            show_state: true
+            columns: 4
+            entities:
+              - entity: sensor.ezhi_photovoltaic_power
+                name: Solar
+              - entity: sensor.ezhi_battery_power
+                name: Battery
+              - entity: sensor.ezhi_on_grid_power
+                name: Grid
+              - entity: sensor.ezhi_off_grid_power
+                name: Backup
+
+      # ------------------------------------------------------------ battery
+      - type: grid
+        cards:
+          - type: heading
+            heading: Battery
+            heading_style: title
+            icon: mdi:battery
+          - type: gauge
+            entity: sensor.ezhi_battery_state_of_charge
+            name: State of charge
+            min: 0
+            max: 100
+            needle: true
+            severity:
+              green: 40
+              yellow: 20
+              red: 0
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.ezhi_battery_status
+                name: Status
+              - entity: sensor.ezhi_battery_temperature
+                name: Temperature
+              - entity: sensor.ezhi_battery_state_of_health
+                name: State of health
+              - entity: sensor.ezhi_battery_capacity
+                name: Capacity
+              - entity: sensor.ezhi_device_temperature
+                name: Inverter temperature
+
+      # ------------------------------------------------------ control local
+      - type: grid
+        cards:
+          - type: heading
+            heading: Control (local)
+            heading_style: title
+            icon: mdi:tune
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.apsystems_ezhi_on_grid_power
+                name: Grid setpoint
+          - type: markdown
+            content: >-
+              Negative discharges to the grid, positive charges from it. This
+              is the one control the local API offers, and it does not persist
+              — something has to keep writing it. Leave it alone unless you
+              are driving the inverter from an automation.
+
+      # ------------------------------------------------------ control cloud
+      #
+      # DELETE THIS WHOLE SECTION if you have not configured cloud control --
+      # these entities only exist when an EMA token pair is set up, and
+      # without them the cards show as unavailable.
+      #
+      # It is a plain section rather than a conditional card on purpose: the
+      # frontend's condition check reads hass.states[entity]?.state, so for an
+      # entity that does not exist at all, "state_not: unavailable" evaluates
+      # true and the card would appear exactly when it should not.
+      - type: grid
+        cards:
+          - type: heading
+            heading: Control (cloud)
+            heading_style: title
+            icon: mdi:cloud-cog
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: switch.apsystems_ezhi_inverter_on
+                name: Inverter
+              - entity: select.apsystems_ezhi_system_mode
+                name: System mode
+              - entity: switch.apsystems_ezhi_backup_power
+                name: Backup power (EPS)
+              - entity: switch.apsystems_ezhi_eco_mode
+                name: ECO mode
+              - type: section
+                label: Limits
+              - entity: number.apsystems_ezhi_soc_minimum
+                name: SOC minimum
+              - entity: number.apsystems_ezhi_soc_maximum
+                name: SOC maximum
+              - entity: number.apsystems_ezhi_discharge_protection
+                name: Discharge protection
+              - entity: number.apsystems_ezhi_preset_output_power
+                name: Preset output power
+              - entity: sensor.apsystems_ezhi_power_limit
+                name: Output ceiling
+          # Buttons, not entity rows: rows in an entities card ignore
+          # tap_action.confirmation, and the 1200 W direction should not be
+          # one stray tap away.
+          - type: horizontal-stack
+            cards:
+              - type: button
+                name: 1200 W
+                icon: mdi:speedometer
+                tap_action:
+                  action: perform-action
+                  perform_action: apsystems_ezhi_local.set_high_power_mode
+                  data:
+                    enable: true
+                    acknowledge_regulatory_risk: true
+                  confirmation:
+                    text: >-
+                      Raise the output ceiling to 1200 W? APsystems warns that
+                      this may cause the device output to exceed regulatory
+                      limits for grid connection, with the responsibility on
+                      the operator.
+              - type: button
+                name: 800 W
+                icon: mdi:speedometer-slow
+                tap_action:
+                  action: perform-action
+                  perform_action: apsystems_ezhi_local.set_high_power_mode
+                  data:
+                    enable: false
+
+      # ------------------------------------------------------------- energy
+      - type: grid
+        cards:
+          - type: heading
+            heading: Energy
+            heading_style: title
+            icon: mdi:chart-box
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.ezhi_photovoltaic_energy
+                name: Solar generated
+              - type: section
+                label: Grid
+              - entity: sensor.ezhi_on_grid_output_energy
+                name: Fed in
+              - entity: sensor.ezhi_on_grid_input_energy
+                name: Drawn
+              - type: section
+                label: Backup output
+              - entity: sensor.ezhi_off_grid_output_energy
+                name: Supplied
+              - entity: sensor.ezhi_off_grid_input_energy
+                name: Received
+              - type: section
+                label: Battery
+              - entity: sensor.ezhi_battery_total_charge_energy
+                name: Charged
+              - entity: sensor.ezhi_battery_total_discharge_energy
+                name: Discharged
+
+      # ------------------------------------------------------------- alarms
+      - type: grid
+        cards:
+          - type: heading
+            heading: Alarms
+            heading_style: title
+            icon: mdi:alert-circle-outline
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - binary_sensor.ezhi_battery_overtemperature
+              - binary_sensor.ezhi_battery_undertemperature
+              - binary_sensor.ezhi_battery_communication_error
+              - binary_sensor.ezhi_battery_overvoltage
+              - binary_sensor.ezhi_battery_undervoltage
+              - binary_sensor.ezhi_battery_overcurrent
+              - binary_sensor.ezhi_battery_error
+              - binary_sensor.ezhi_battery_shutdown
+              - binary_sensor.ezhi_device_overtemperature
+              - binary_sensor.ezhi_device_error
+              - binary_sensor.ezhi_ac_abnormal
+              - binary_sensor.ezhi_off_grid_overcurrent
+              - binary_sensor.ezhi_off_grid_short_circuit
+              - binary_sensor.ezhi_pv_overvoltage
+              - binary_sensor.ezhi_pv_overcurrent
+              - binary_sensor.ezhi_pv_wiring_error
+              - binary_sensor.ezhi_ird_error
+
+      # ------------------------------------------------------------ history
+      - type: grid
+        cards:
+          - type: heading
+            heading: History
+            heading_style: title
+            icon: mdi:chart-line
+          - type: history-graph
+            hours_to_show: 24
+            entities:
+              - entity: sensor.ezhi_battery_state_of_charge
+                name: State of charge
+              - entity: sensor.ezhi_battery_power
+                name: Battery power
+              - entity: sensor.ezhi_photovoltaic_power
+                name: Solar

--- a/examples/dashboard.yaml
+++ b/examples/dashboard.yaml
@@ -1,0 +1,255 @@
+# Example dashboard for the APsystems EZHI integration.
+#
+# HOW TO USE
+#   Settings -> Dashboards -> Add dashboard -> New dashboard from scratch.
+#   Open it, then: pencil icon -> three dots -> Raw configuration editor,
+#   and replace everything there with this file.
+#
+# ENTITY IDS
+#   This file assumes the integration was added with the name "ezhi". If you
+#   used a different name, replace "ezhi" throughout.
+#   Careful: the prefixes are not uniform. The local sensors are
+#   "sensor.ezhi_...", while the cloud entities and the local power number
+#   carry an extra "apsystems_": "switch.apsystems_ezhi_...". The exact ids
+#   for your install are listed on the device page under
+#   Settings -> Devices & Services -> APsystems EZHI -> your device.
+#
+# REQUIRED CUSTOM CARDS (install via HACS first)
+#   Mushroom         https://github.com/piitaya/lovelace-mushroom
+#   fold-entity-row  https://github.com/thomasloven/lovelace-fold-entity-row
+#   Without them the affected cards render as "Custom element doesn't exist".
+#   examples/dashboard-core.yaml is the same dashboard built only from cards
+#   Home Assistant ships with, if you would rather not install anything.
+
+views:
+  - title: EZHI
+    path: ezhi
+    type: sections
+    max_columns: 2
+    sections:
+      # ---------------------------------------------------------------- now
+      - type: grid
+        cards:
+          - type: heading
+            heading: Now
+            heading_style: title
+            icon: mdi:flash
+          - type: custom:mushroom-entity-card
+            entity: sensor.ezhi_photovoltaic_power
+            name: Solar
+            icon: mdi:solar-power-variant
+            icon_color: amber
+          - type: custom:mushroom-entity-card
+            entity: sensor.ezhi_battery_power
+            name: Battery
+            icon: mdi:battery-charging
+            icon_color: green
+          - type: custom:mushroom-entity-card
+            entity: sensor.ezhi_on_grid_power
+            name: Grid
+            icon: mdi:transmission-tower
+            icon_color: blue
+          - type: custom:mushroom-entity-card
+            entity: sensor.ezhi_off_grid_power
+            name: Backup output
+            icon: mdi:power-plug-off
+            icon_color: purple
+
+      # ------------------------------------------------------------ battery
+      - type: grid
+        cards:
+          - type: heading
+            heading: Battery
+            heading_style: title
+            icon: mdi:battery
+          - type: gauge
+            entity: sensor.ezhi_battery_state_of_charge
+            name: State of charge
+            min: 0
+            max: 100
+            needle: true
+            severity:
+              green: 40
+              yellow: 20
+              red: 0
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.ezhi_battery_status
+                name: Status
+              - entity: sensor.ezhi_battery_temperature
+                name: Temperature
+              - entity: sensor.ezhi_battery_state_of_health
+                name: State of health
+              - entity: sensor.ezhi_battery_capacity
+                name: Capacity
+              - entity: sensor.ezhi_device_temperature
+                name: Inverter temperature
+
+      # ------------------------------------------------------ control local
+      - type: grid
+        cards:
+          - type: heading
+            heading: Control (local)
+            heading_style: title
+            icon: mdi:tune
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.apsystems_ezhi_on_grid_power
+                name: Grid setpoint
+          - type: markdown
+            content: >-
+              Negative discharges to the grid, positive charges from it. This
+              is the one control the local API offers, and it does not persist
+              — something has to keep writing it. Leave it alone unless you
+              are driving the inverter from an automation.
+
+      # ------------------------------------------------------ control cloud
+      #
+      # DELETE THIS WHOLE SECTION if you have not configured cloud control --
+      # these entities only exist when an EMA token pair is set up, and
+      # without them the cards show as unavailable.
+      #
+      # It is a plain section rather than a conditional card on purpose: the
+      # frontend's condition check reads hass.states[entity]?.state, so for an
+      # entity that does not exist at all, "state_not: unavailable" evaluates
+      # true and the card would appear exactly when it should not.
+      - type: grid
+        cards:
+          - type: heading
+            heading: Control (cloud)
+            heading_style: title
+            icon: mdi:cloud-cog
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: switch.apsystems_ezhi_inverter_on
+                name: Inverter
+              - entity: select.apsystems_ezhi_system_mode
+                name: System mode
+              - entity: switch.apsystems_ezhi_backup_power
+                name: Backup power (EPS)
+              - entity: switch.apsystems_ezhi_eco_mode
+                name: ECO mode
+              - type: section
+                label: Limits
+              - entity: number.apsystems_ezhi_soc_minimum
+                name: SOC minimum
+              - entity: number.apsystems_ezhi_soc_maximum
+                name: SOC maximum
+              - entity: number.apsystems_ezhi_discharge_protection
+                name: Discharge protection
+              - entity: number.apsystems_ezhi_preset_output_power
+                name: Preset output power
+              - entity: sensor.apsystems_ezhi_power_limit
+                name: Output ceiling
+          # Buttons, not entity rows: rows in an entities card ignore
+          # tap_action.confirmation, and the 1200 W direction should not be
+          # one stray tap away.
+          - type: horizontal-stack
+            cards:
+              - type: button
+                name: 1200 W
+                icon: mdi:speedometer
+                tap_action:
+                  action: perform-action
+                  perform_action: apsystems_ezhi_local.set_high_power_mode
+                  data:
+                    enable: true
+                    acknowledge_regulatory_risk: true
+                  confirmation:
+                    text: >-
+                      Raise the output ceiling to 1200 W? APsystems warns that
+                      this may cause the device output to exceed regulatory
+                      limits for grid connection, with the responsibility on
+                      the operator.
+              - type: button
+                name: 800 W
+                icon: mdi:speedometer-slow
+                tap_action:
+                  action: perform-action
+                  perform_action: apsystems_ezhi_local.set_high_power_mode
+                  data:
+                    enable: false
+
+      # ------------------------------------------------------------- energy
+      - type: grid
+        cards:
+          - type: heading
+            heading: Energy
+            heading_style: title
+            icon: mdi:chart-box
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.ezhi_photovoltaic_energy
+                name: Solar generated
+              - type: section
+                label: Grid
+              - entity: sensor.ezhi_on_grid_output_energy
+                name: Fed in
+              - entity: sensor.ezhi_on_grid_input_energy
+                name: Drawn
+              - type: section
+                label: Backup output
+              - entity: sensor.ezhi_off_grid_output_energy
+                name: Supplied
+              - entity: sensor.ezhi_off_grid_input_energy
+                name: Received
+              - type: section
+                label: Battery
+              - entity: sensor.ezhi_battery_total_charge_energy
+                name: Charged
+              - entity: sensor.ezhi_battery_total_discharge_energy
+                name: Discharged
+
+      # ------------------------------------------------------------- alarms
+      - type: grid
+        cards:
+          - type: heading
+            heading: Alarms
+            heading_style: title
+            icon: mdi:alert-circle-outline
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - type: custom:fold-entity-row
+                head:
+                  type: section
+                  label: All alarms
+                entities:
+                  - binary_sensor.ezhi_battery_overtemperature
+                  - binary_sensor.ezhi_battery_undertemperature
+                  - binary_sensor.ezhi_battery_communication_error
+                  - binary_sensor.ezhi_battery_overvoltage
+                  - binary_sensor.ezhi_battery_undervoltage
+                  - binary_sensor.ezhi_battery_overcurrent
+                  - binary_sensor.ezhi_battery_error
+                  - binary_sensor.ezhi_battery_shutdown
+                  - binary_sensor.ezhi_device_overtemperature
+                  - binary_sensor.ezhi_device_error
+                  - binary_sensor.ezhi_ac_abnormal
+                  - binary_sensor.ezhi_off_grid_overcurrent
+                  - binary_sensor.ezhi_off_grid_short_circuit
+                  - binary_sensor.ezhi_pv_overvoltage
+                  - binary_sensor.ezhi_pv_overcurrent
+                  - binary_sensor.ezhi_pv_wiring_error
+                  - binary_sensor.ezhi_ird_error
+
+      # ------------------------------------------------------------ history
+      - type: grid
+        cards:
+          - type: heading
+            heading: History
+            heading_style: title
+            icon: mdi:chart-line
+          - type: history-graph
+            hours_to_show: 24
+            entities:
+              - entity: sensor.ezhi_battery_state_of_charge
+                name: State of charge
+              - entity: sensor.ezhi_battery_power
+                name: Battery power
+              - entity: sensor.ezhi_photovoltaic_power
+                name: Solar

--- a/examples/dashboard.yaml
+++ b/examples/dashboard.yaml
@@ -147,6 +147,11 @@ views:
           # Buttons, not entity rows: rows in an entities card ignore
           # tap_action.confirmation, and the 1200 W direction should not be
           # one stray tap away.
+          #
+          # The button carries acknowledge_regulatory_risk: true because the
+          # confirmation dialog below is where the disclaimer is actually read
+          # and accepted. Do not copy that flag into an automation, where
+          # nothing asks anyone anything.
           - type: horizontal-stack
             cards:
               - type: button

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,13 @@
   "name": "APsystems EZHI Local API",
   "render_readme": true,
   "content_in_root": false,
-  "domains": ["sensor", "number", "binary_sensor"],
-  "homeassistant": "2023.5.0",
+  "domains": [
+    "sensor",
+    "number",
+    "binary_sensor",
+    "switch",
+    "select"
+  ],
+  "homeassistant": "2024.11.0",
   "iot_class": "Local Polling"
 }

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -351,3 +351,21 @@ def test_rejected_write_raises():
 
     with pytest.raises(cloud.EzhiCloudError):
         asyncio.run(api.async_set_soc_limit(20, 95))
+
+    assert len(session.calls_to("socLimit")) == 1
+
+
+def test_set_soc_limit_rejects_implausible_bounds():
+    """This writes real hardware config -- validate at the boundary even
+    though the number entity will validate too. Must fail before any network
+    call, not after."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_set_soc_limit(95, 20))
+
+    assert session.calls == []

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -27,8 +27,10 @@ class FakeResponse:
     def __init__(self, status: int, body: dict):
         self.status = status
         self._body = body
+        self.json_calls = 0
 
     async def json(self, content_type=None):
+        self.json_calls += 1
         return self._body
 
 
@@ -50,7 +52,12 @@ class FakeSession:
         )
         for key, queue in self.script.items():
             if key in url:
-                return queue.pop(0) if len(queue) > 1 else queue[0]
+                item = queue.pop(0) if len(queue) > 1 else queue[0]
+                # A scripted Exception simulates a transport failure (e.g. a
+                # dropped connection) instead of an HTTP response.
+                if isinstance(item, Exception):
+                    raise item
+                return item
         raise AssertionError(f"unscripted call: {method} {url}")
 
     def calls_to(self, needle: str) -> list[dict]:
@@ -160,6 +167,37 @@ def test_cached_token_is_reused():
 
     assert len(session.calls_to("refreshToken")) == 1
     assert len(session.calls_to("systemMode")) == 2
+
+
+def test_non_200_response_still_reads_body_to_release_connection():
+    """response.json() must be awaited even on failure. In real aiohttp that
+    is what releases the connection back to the pool; it also means the
+    server's error message is available instead of silently discarded."""
+    response = FakeResponse(400, {"message": "bad request"})
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [response],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_get_config())
+
+    assert response.json_calls == 1
+
+
+def test_transport_error_is_wrapped_as_cloud_error():
+    """Nothing coming out of session.request may escape the exception
+    hierarchy raw -- every caller downstream only knows about EzhiCloudError
+    and its subclasses."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [OSError("boom")],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_get_config())
 
 
 def test_build_params_carries_untouched_fields_forward():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -236,6 +236,42 @@ def test_transport_error_is_wrapped_as_cloud_error():
         asyncio.run(api.async_get_config())
 
 
+class FakeClientError(Exception):
+    """Stands in for aiohttp.ClientError, which cloud.py cannot import to
+    catch by name. An OSError-only test would miss a narrowed `except
+    OSError` that still wraps every real-world transport failure it needs
+    to; this is not an OSError, so it forces the catch to stay broad."""
+
+
+def test_non_os_transport_error_is_also_wrapped():
+    """A genuine aiohttp.ClientError (modelled here, since we cannot import
+    it) must be wrapped exactly like an OSError is -- the transport catch
+    must not be narrowly OSError-shaped."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [FakeClientError("connection reset")],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_get_config())
+
+
+def test_programming_error_propagates_unwrapped():
+    """A bug in our own code (e.g. a malformed data payload raising
+    TypeError) must surface as itself, not get misdiagnosed as a network
+    problem -- the coordinator maps EzhiCloudError to a silent forever-retry,
+    which would bury the traceback that shows the actual bug."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [TypeError("boom")],
+    })
+    api = make_api(session)
+
+    with pytest.raises(TypeError):
+        asyncio.run(api.async_get_config())
+
+
 def test_build_params_carries_untouched_fields_forward():
     """A mode switch must not silently drop the EPS/backup release."""
     params = cloud.build_system_mode_params(CONFIG, systemMode="4")

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -460,16 +460,19 @@ def test_turn_off_sends_status_one():
 def test_turn_on_with_reason_1_raises_offline_error():
     """on=True, reason:1 -> the cloud cannot wake a powered-down inverter.
     reason:1 means offline regardless of direction; the ON case also gets
-    the concrete battery-button advice."""
+    the concrete battery-button advice. Asserting on the message content
+    (not just the exception type) is what kills a mutant that drops the
+    `if on:` branch and puts this advice on the OFF case too."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
         "onOff": [ok({"flag": False, "reason": 1})],
     })
     api = make_api(session)
 
-    with pytest.raises(cloud.EzhiCloudOfflineError):
+    with pytest.raises(cloud.EzhiCloudOfflineError) as exc_info:
         asyncio.run(api.async_set_on_off(True))
 
+    assert "battery button" in str(exc_info.value)
     assert len(session.calls_to("onOff")) == 1
 
 
@@ -492,16 +495,19 @@ def test_turn_off_with_reason_1_raises_offline_error():
     """on=False, reason:1 -> offline is about reachability, not direction. If
     the inverter is offline and OFF is sent, it will likely also answer
     reason:1 -- a caller that handles offline specially must still see it,
-    just without the ON-specific battery-button advice."""
+    just without the ON-specific battery-button advice. Asserting the advice
+    is ABSENT here is what pairs with the ON test's assertion that it IS
+    present, together killing a mutant that drops the `if on:` branch."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
         "onOff": [ok({"flag": False, "reason": 1})],
     })
     api = make_api(session)
 
-    with pytest.raises(cloud.EzhiCloudOfflineError):
+    with pytest.raises(cloud.EzhiCloudOfflineError) as exc_info:
         asyncio.run(api.async_set_on_off(False))
 
+    assert "battery button" not in str(exc_info.value)
     assert len(session.calls_to("onOff")) == 1
 
 
@@ -544,6 +550,21 @@ def test_set_system_mode_posts_full_params_json():
     assert json.loads(post_call["data"]["params"]) == {
         "systemMode": "4", "EPS": "1", "ECO": "0", "userSetPower": "200",
     }
+
+
+def test_set_system_mode_raises_on_rejection():
+    """flag:false is a failure, never a success -- a rejected mode change
+    must not silently count as one. The flag check already exists in the
+    code but, before this test, deleting it left the suite green: the only
+    existing test scripted flag:True and only asserted the payload."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG), ok({"flag": False})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_set_system_mode(systemMode="4"))
 
 
 def test_set_soc_limit_sends_both_bounds():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -383,6 +383,19 @@ def test_timeout_error_message_names_the_budget():
         asyncio.run(api.async_get_config())
 
 
+def test_transport_failure_message_includes_the_url():
+    """Token and API failures must not read identically in the HA log --
+    include the URL so a transport failure on the token endpoint is
+    distinguishable from one on an API endpoint."""
+    session = FakeSession({
+        "refreshToken": [OSError("boom")],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="refreshToken"):
+        asyncio.run(api.async_get_config())
+
+
 def test_build_params_carries_untouched_fields_forward():
     """A mode switch must not silently drop the EPS/backup release."""
     params = cloud.build_system_mode_params(CONFIG, systemMode="4")
@@ -423,6 +436,20 @@ def test_build_params_normalises_bool_to_wire_string():
     params = cloud.build_system_mode_params(config)
 
     assert params["EPS"] == "1"
+
+
+def test_is_truthy_accepts_json_bool_and_string_spelling():
+    """The capture suggests real JSON booleans for write responses, but every
+    field of the GET payload is a string -- the cloud plausibly sends both
+    spellings, and bool("false") is True in plain Python."""
+    assert cloud._is_truthy(True) is True
+    assert cloud._is_truthy(False) is False
+    assert cloud._is_truthy("true") is True
+    assert cloud._is_truthy("1") is True
+    assert cloud._is_truthy("false") is False
+    assert cloud._is_truthy("0") is False
+    assert cloud._is_truthy("") is False
+    assert cloud._is_truthy(None) is False
 
 
 def test_turn_on_sends_status_zero():
@@ -511,6 +538,21 @@ def test_turn_off_with_reason_1_raises_offline_error():
     assert len(session.calls_to("onOff")) == 1
 
 
+def test_turn_on_with_string_reason_1_still_raises_offline_error():
+    """reason:"1" (string) must be recognised the same as reason:1 (int) --
+    Task 5 only probes the GET, never a write response, so the write
+    response's field types are unverified. A bare `== 1` comparison would
+    silently miss the string spelling."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": False, "reason": "1"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudOfflineError):
+        asyncio.run(api.async_set_on_off(True))
+
+
 def test_turn_off_with_other_reason_raises_plain_error():
     """on=False, reason:7 (not 1) -> a rejected OFF for some other reason
     must not be misdiagnosed as the device being offline."""
@@ -595,6 +637,22 @@ def test_rejected_write_raises():
         asyncio.run(api.async_set_soc_limit(20, 95))
 
     assert len(session.calls_to("socLimit")) == 1
+
+
+def test_rejected_write_with_string_flag_still_raises():
+    """Task 5 only probes the GET, never a write response -- the capture
+    suggests real JSON booleans for `flag`, but every field of the GET
+    payload is a string, so a write response plausibly sends "false" too.
+    bool("false") is True in plain Python: a rejected write would silently
+    count as success without a spelling-tolerant check."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "socLimit": [ok({"flag": "false"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_set_soc_limit(20, 95))
 
 
 def test_set_soc_limit_rejects_implausible_bounds():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -275,6 +275,50 @@ def test_non_200_response_still_reads_body_to_release_connection():
     assert response.json_calls == 1
 
 
+def test_non_200_status_raises_even_when_body_code_is_zero():
+    """A 5xx with a body that (oddly) claims code:0 must still raise on the
+    HTTP status. Without this, test_non_200_response_still_reads_body_to_-
+    release_connection is caught by two guards at once (status!=200, and the
+    code!=0 fallback since its body has no "code" key) and pins neither --
+    this isolates the status!=200 guard specifically."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [FakeResponse(500, {"code": 0})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_get_config())
+
+
+def test_api_call_with_auth_error_code_raises_auth_error():
+    """The body-code route is exactly how dead credentials get reported --
+    covered on the token endpoint, but this pins it on an API endpoint too.
+    Without a test, `if code in AUTH_ERROR_CODES` can be deleted from _call
+    and every test still passes: it silently falls through to the generic
+    code!=0 branch instead of the specific auth one."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [FakeResponse(200, {"code": 3001, "message": "bad"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(api.async_get_config())
+
+
+def test_api_call_with_offline_code_raises_offline_error():
+    """Same gap as above, for `if code == DEVICE_OFFLINE_CODE`."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [FakeResponse(200, {"code": 1001, "message": "offline"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudOfflineError):
+        asyncio.run(api.async_get_config())
+
+
 def test_transport_error_is_wrapped_as_cloud_error():
     """Nothing coming out of session.request may escape the exception
     hierarchy raw -- every caller downstream only knows about EzhiCloudError

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -452,6 +452,31 @@ def test_is_truthy_accepts_json_bool_and_string_spelling():
     assert cloud._is_truthy(None) is False
 
 
+def test_is_running_true_for_the_zero_spellings():
+    """"0" (the capture), 0, False and 0.0 all mean "the inverter is
+    running" -- switch.py's is_on and this must agree on what onOff's payload
+    type actually is, and the test fixtures in this very file disagree with
+    each other about it (line ~98 has a string socMin, line ~410 an int).
+    Routed through _wire_str, the same normalisation async_set_on_off's
+    request body already relies on."""
+    assert cloud.is_running("0") is True
+    assert cloud.is_running(0) is True
+    assert cloud.is_running(False) is True
+    assert cloud.is_running(0.0) is True
+
+
+def test_is_running_false_for_the_one_spellings():
+    assert cloud.is_running("1") is False
+    assert cloud.is_running(1) is False
+    assert cloud.is_running(True) is False
+
+
+def test_is_running_none_when_unknown():
+    """No data yet -- not "off", which would tell an is_state('off')
+    automation the wrong thing before the first poll has landed."""
+    assert cloud.is_running(None) is None
+
+
 def test_turn_on_sends_status_zero():
     """status=0 turns the inverter ON. Inverted, and verified in the capture."""
     session = FakeSession({
@@ -669,6 +694,64 @@ def test_set_soc_limit_rejects_implausible_bounds():
         asyncio.run(api.async_set_soc_limit(95, 20))
 
     assert session.calls == []
+
+
+def test_set_soc_limit_with_both_bounds_does_not_re_read():
+    """Both bounds supplied -- nothing stale to protect against, so no GET."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(20, 95))
+
+    assert session.calls_to("systemMode") == []
+
+
+def test_set_soc_limit_fetches_the_omitted_bound():
+    """Setting only socMax must not trust a cached socMin -- a poll can be up
+    to a minute old, and writing a stale bound back would revert a change
+    made from the vendor app meanwhile. Same freshness rule as
+    async_set_system_mode, now applied to its twin endpoint too."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        # The socLimit-fetch GET reuses the systemMode endpoint (async_get_config).
+        "systemMode": [ok(CONFIG)],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(soc_max=90))
+
+    assert len(session.calls_to("systemMode")) == 1
+    post_call = session.calls_to("socLimit")[0]
+    assert post_call["data"]["socMin"] == "10"  # CONFIG's socMin, freshly read
+    assert post_call["data"]["socMax"] == "90"
+
+
+def test_set_soc_limit_raises_when_fetched_config_lacks_the_bound():
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok({"onOff": "0"})],  # no socMin/socMax in this payload
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="socMin/socMax"):
+        asyncio.run(api.async_set_soc_limit(soc_max=90))
+
+
+def test_set_soc_limit_rejects_non_numeric_config_field():
+    """A malformed cloud value must surface as EzhiCloudError, not a bare
+    ValueError escaping past the client's documented exception contract."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok({**CONFIG, "socMin": "not-a-number"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="socMin"):
+        asyncio.run(api.async_set_soc_limit(soc_max=90))
 
 
 def test_concurrent_first_calls_trigger_exactly_one_refresh():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -185,6 +185,59 @@ def test_dead_refresh_token_with_unparsable_body_raises_auth_error():
         asyncio.run(api.async_get_config())
 
 
+def test_refresh_token_401_raises_auth_error():
+    """401 on the token endpoint means the credentials themselves are
+    rejected."""
+    session = FakeSession({
+        "refreshToken": [FakeResponse(401, {})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(api.async_get_config())
+
+
+def test_refresh_token_403_raises_auth_error():
+    """403, like 401, means the credentials are rejected."""
+    session = FakeSession({
+        "refreshToken": [FakeResponse(403, {})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(api.async_get_config())
+
+
+def test_refresh_token_502_is_retryable_not_auth_error():
+    """A transient 5xx from the cloud is not a dead credential. Escalating
+    this to EzhiCloudAuthError would (via the coordinator) stop HA polling
+    and send the user on a pointless token re-capture that cannot fix a
+    server-side outage -- and it would never recover on its own."""
+    session = FakeSession({
+        "refreshToken": [FakeResponse(502, {})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError) as exc_info:
+        asyncio.run(api.async_get_config())
+
+    assert not isinstance(exc_info.value, cloud.EzhiCloudAuthError)
+
+
+def test_refresh_token_429_is_retryable_not_auth_error():
+    """429 (rate limited) is the cloud being unwell, not the credentials
+    being dead -- same reasoning as the 502 case."""
+    session = FakeSession({
+        "refreshToken": [FakeResponse(429, {})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError) as exc_info:
+        asyncio.run(api.async_get_config())
+
+    assert not isinstance(exc_info.value, cloud.EzhiCloudAuthError)
+
+
 def test_cached_token_is_reused():
     """A second call inside the TTL must not refresh again."""
     session = FakeSession({

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1220,3 +1220,43 @@ def test_the_schedule_itself_is_never_written_back():
     asyncio.run(api.async_set_high_power(True))
 
     assert "outputPowerStrategyWeekly" not in _system_mode_params(session)
+
+
+# --- concurrent writes ------------------------------------------------------
+
+def test_two_writes_do_not_interleave_their_read_modify_write():
+    """Setting SOC minimum and maximum back to back must not lose one.
+
+    Both calls are GET-then-POST. Without a lock held across the pair, the
+    second GET can land before the first POST, so the second write carries the
+    pre-change value and silently undoes the first -- with both reporting
+    success. The FakeSession yields to the loop on every request, so an
+    unlocked implementation really does interleave here.
+    """
+    order: list[str] = []
+
+    class TracingSession(FakeSession):
+        async def request(self, method, url, params=None, data=None, headers=None):
+            if "systemMode" in url and method == "GET":
+                order.append("read")
+            elif "socLimit" in url:
+                order.append("write")
+            return await super().request(method, url, params, data, headers)
+
+    session = TracingSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    async def both():
+        await asyncio.gather(
+            api.async_set_soc_limit(soc_min=15),
+            api.async_set_soc_limit(soc_max=90),
+        )
+
+    asyncio.run(both())
+
+    # Each write's read must be immediately followed by its own write.
+    assert order == ["read", "write", "read", "write"], order

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -514,6 +514,31 @@ def test_is_running_none_for_an_unmapped_value():
     assert cloud.is_running("") is None
 
 
+def test_api_url_carries_the_v2_segment():
+    """Every endpoint hangs off /aps-api-web/api/v2 -- measured, not inferred.
+
+    Drop the segment and the cloud answers HTTP 200 with body code 4 "Internal
+    Server Error" on every call: it looks like an outage, so the wrong path
+    would be blamed on APsystems rather than on us. `endswith` assertions on the
+    endpoint alone cannot catch that, hence this one pins the prefix.
+    """
+    assert cloud.API_URL == "https://app.api.apsystemsema.com:9223/aps-api-web/api/v2"
+    # The token endpoint sits outside both the app path and the versioning.
+    assert cloud.TOKEN_URL == "https://app.api.apsystemsema.com:9223/api/token/refreshToken"
+
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+    })
+    api = make_api(session)
+    asyncio.run(api.async_get_config())
+
+    assert session.calls_to("systemMode")[0]["url"] == (
+        "https://app.api.apsystemsema.com:9223"
+        "/aps-api-web/api/v2/remote/ezInverter/systemMode"
+    )
+
+
 def test_turn_on_sends_status_zero():
     """status=0 turns the inverter ON. Inverted, and verified in the capture."""
     session = FakeSession({

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -438,6 +438,34 @@ def test_build_params_normalises_bool_to_wire_string():
     assert params["EPS"] == "1"
 
 
+def test_build_params_carries_optional_fields_when_present():
+    """dischargeProtection (a real battery deep-discharge floor, live value
+    seen: 12%), stayOn, governmentLevies and area are carried forward when
+    the config has them. Merge-vs-replace is unresolved for this endpoint --
+    carrying these is harmless if the cloud merges and essential if it
+    replaces."""
+    config = {**CONFIG, "dischargeProtection": "12", "stayOn": "0",
+              "governmentLevies": "1", "area": "DE"}
+
+    params = cloud.build_system_mode_params(config, systemMode="4")
+
+    assert params["dischargeProtection"] == "12"
+    assert params["stayOn"] == "0"
+    assert params["governmentLevies"] == "1"
+    assert params["area"] == "DE"
+
+
+def test_build_params_optional_fields_absence_does_not_raise():
+    """Unlike the required four, a config lacking the optional four must not
+    block a mode write."""
+    params = cloud.build_system_mode_params(CONFIG, systemMode="4")
+
+    assert "dischargeProtection" not in params
+    assert "stayOn" not in params
+    assert "governmentLevies" not in params
+    assert "area" not in params
+
+
 def test_is_truthy_accepts_json_bool_and_string_spelling():
     """The capture suggests real JSON booleans for write responses, but every
     field of the GET payload is a string -- the cloud plausibly sends both
@@ -457,7 +485,7 @@ def test_is_running_true_for_the_zero_spellings():
     running" -- switch.py's is_on and this must agree on what onOff's payload
     type actually is, and the test fixtures in this very file disagree with
     each other about it (line ~98 has a string socMin, line ~410 an int).
-    Routed through _wire_str, the same normalisation async_set_on_off's
+    Routed through wire_str, the same normalisation async_set_on_off's
     request body already relies on."""
     assert cloud.is_running("0") is True
     assert cloud.is_running(0) is True
@@ -475,6 +503,15 @@ def test_is_running_none_when_unknown():
     """No data yet -- not "off", which would tell an is_state('off')
     automation the wrong thing before the first poll has landed."""
     assert cloud.is_running(None) is None
+
+
+def test_is_running_none_for_an_unmapped_value():
+    """A value that normalises to neither "0" nor "1" must not be reported as
+    "off" with false confidence -- the previous implementation's implicit
+    `else False` would fail on the dangerous side: is_state(..., 'off') ->
+    turn_on firing a hardware write while the inverter might be running."""
+    assert cloud.is_running("2") is None
+    assert cloud.is_running("") is None
 
 
 def test_turn_on_sends_status_zero():
@@ -591,6 +628,23 @@ def test_turn_off_with_other_reason_raises_plain_error():
         asyncio.run(api.async_set_on_off(False))
 
     assert not isinstance(exc_info.value, cloud.EzhiCloudOfflineError)
+
+
+def test_turn_on_with_float_or_bool_reason_1_still_raises_offline_error():
+    """reason:1.0 or reason:True must land on the offline branch too -- a
+    bare str() comparison (str(1.0) == "1.0", str(True) == "True") would
+    silently fall through to the generic error and the user loses the
+    battery-button recovery advice. Same fix as is_running, applied to the
+    write response's reason field."""
+    for reason in (1.0, True):
+        session = FakeSession({
+            "refreshToken": [ok({"access_token": "JWT-1"})],
+            "onOff": [ok({"flag": False, "reason": reason})],
+        })
+        api = make_api(session)
+
+        with pytest.raises(cloud.EzhiCloudOfflineError):
+            asyncio.run(api.async_set_on_off(True))
 
 
 def test_set_system_mode_posts_full_params_json():
@@ -728,6 +782,44 @@ def test_set_soc_limit_fetches_the_omitted_bound():
     post_call = session.calls_to("socLimit")[0]
     assert post_call["data"]["socMin"] == "10"  # CONFIG's socMin, freshly read
     assert post_call["data"]["socMax"] == "90"
+
+
+def test_set_soc_limit_fetches_the_omitted_min_bound():
+    """The mirror of test_set_soc_limit_fetches_the_omitted_bound, and the
+    exact path number.EzhiCloudSocNumber's async_set_native_value takes on
+    every single write of *_soc_minimum: only soc_min supplied, soc_max
+    fetched fresh."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(soc_min=15))
+
+    assert len(session.calls_to("systemMode")) == 1
+    post_call = session.calls_to("socLimit")[0]
+    assert post_call["data"]["socMin"] == "15"
+    assert post_call["data"]["socMax"] == "100"  # CONFIG's socMax, freshly read
+
+
+def test_set_soc_limit_accepts_a_float_style_string_bound():
+    """The read side (number.py's _safe_float) is fine with "100.0"; the
+    write side must accept exactly what the read side just displayed. Before
+    this, editing only socMin failed whenever the untouched socMax came back
+    from the cloud as "100.0", because _to_int's plain int() rejects it."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok({**CONFIG, "socMax": "100.0"})],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(soc_min=15))
+
+    post_call = session.calls_to("socLimit")[0]
+    assert post_call["data"]["socMax"] == "100"
 
 
 def test_set_soc_limit_raises_when_fetched_config_lacks_the_bound():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -115,17 +115,20 @@ def test_401_triggers_exactly_one_refresh_and_retry():
 
 
 def test_second_401_is_not_retried_again():
-    """One retry, not a loop."""
+    """One retry, not a loop. A 401 that survives the retry means the stored
+    credentials are dead, not transient -- that must surface as an auth error
+    so the caller can offer reauth instead of retrying forever."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
         "systemMode": [FakeResponse(401, {})],
     })
     api = make_api(session)
 
-    with pytest.raises(cloud.EzhiCloudError):
+    with pytest.raises(cloud.EzhiCloudAuthError):
         asyncio.run(api.async_get_config())
 
     assert len(session.calls_to("systemMode")) == 2
+    assert len(session.calls_to("refreshToken")) == 2
 
 
 def test_dead_refresh_token_raises_auth_error():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -301,20 +301,27 @@ def test_turn_off_rejection_raises_plain_error_not_offline():
 
 
 def test_set_system_mode_posts_full_params_json():
+    """async_set_system_mode fetches its own fresh config rather than trusting
+    a cached one -- a poll can be up to a minute old, and writing a stale
+    EPS/ECO back would undo a change made from the vendor app meanwhile."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
-        "systemMode": [ok({"flag": True})],
+        # GET (fresh config) then POST (the write), same URL substring.
+        "systemMode": [ok(CONFIG), ok({"flag": True})],
     })
     api = make_api(session)
 
-    asyncio.run(api.async_set_system_mode(CONFIG, systemMode="4"))
+    asyncio.run(api.async_set_system_mode(systemMode="4"))
 
-    call = session.calls_to("systemMode")[0]
-    assert call["method"] == "POST"
-    assert call["data"]["deviceId"] == "D02000000577"
-    assert call["data"]["identifierType"] == "1"
-    assert call["data"]["maxPowerFlag"] == "0"
-    assert json.loads(call["data"]["params"]) == {
+    calls = session.calls_to("systemMode")
+    assert len(calls) == 2
+    get_call, post_call = calls
+    assert get_call["method"] == "GET"
+    assert post_call["method"] == "POST"
+    assert post_call["data"]["deviceId"] == "D02000000577"
+    assert post_call["data"]["identifierType"] == "1"
+    assert post_call["data"]["maxPowerFlag"] == "0"
+    assert json.loads(post_call["data"]["params"]) == {
         "systemMode": "4", "EPS": "1", "ECO": "0", "userSetPower": "200",
     }
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -86,7 +86,7 @@ def ok(data: dict) -> FakeResponse:
 
 def make_api(session, **kwargs):
     defaults = dict(
-        device_id="D02000000577",
+        device_id="D00000000000",
         access_token="BOOTSTRAP",
         refresh_token="RT-UUID",
     )
@@ -553,7 +553,7 @@ def test_turn_on_sends_status_zero():
     assert len(calls) == 1
     call = calls[0]
     assert call["method"] == "POST"
-    assert call["url"].endswith("/remote/ezInverter/onOff/D02000000577")
+    assert call["url"].endswith("/remote/ezInverter/onOff/D00000000000")
     assert call["data"]["status"] == "0"
 
 
@@ -690,7 +690,7 @@ def test_set_system_mode_posts_full_params_json():
     get_call, post_call = calls
     assert get_call["method"] == "GET"
     assert post_call["method"] == "POST"
-    assert post_call["data"]["deviceId"] == "D02000000577"
+    assert post_call["data"]["deviceId"] == "D00000000000"
     assert post_call["data"]["identifierType"] == "1"
     assert post_call["data"]["maxPowerFlag"] == "0"
     assert json.loads(post_call["data"]["params"]) == {
@@ -908,7 +908,7 @@ def test_get_config_uses_deviceId_type_language_params():
 
     call = session.calls_to("systemMode")[0]
     assert call["params"] == {
-        "deviceId": "D02000000577", "type": "EZHI", "language": "en",
+        "deviceId": "D00000000000", "type": "EZHI", "language": "en",
     }
 
 

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -717,6 +717,7 @@ def test_set_soc_limit_sends_both_bounds():
     """The socLimit endpoint takes both bounds, so both always travel."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
         "socLimit": [ok({"flag": True})],
     })
     api = make_api(session)
@@ -733,6 +734,7 @@ def test_rejected_write_raises():
     """flag:false is a failure, never a success."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
         "socLimit": [ok({"flag": False})],
     })
     api = make_api(session)
@@ -775,17 +777,67 @@ def test_set_soc_limit_rejects_implausible_bounds():
     assert session.calls == []
 
 
-def test_set_soc_limit_with_both_bounds_does_not_re_read():
-    """Both bounds supplied -- nothing stale to protect against, so no GET."""
+def test_raising_soc_min_past_the_discharge_floor_is_refused_here_too():
+    """The bug this pair of tests exists for.
+
+    The guard lived only on the systemMode path, while the shipped SOC Minimum
+    entity writes through socLimit -- so the entity could set a floor the app
+    refuses and the device then silently clamps. Live config at the time:
+    dischargeProtection 12, socMin 10.
+    """
+    config = {**CONFIG, "socMin": "10", "dischargeProtection": "12"}
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(config)],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="discharge protection"):
+        asyncio.run(api.async_set_soc_limit(soc_min=30))
+
+    assert session.calls_to("socLimit") == []   # refused before the write
+
+
+def test_soc_max_alone_is_not_blocked_by_an_existing_bad_pair():
+    """Only the value the caller moves is judged.
+
+    A config that already violates the rule must not make an unrelated socMax
+    change impossible -- the same carry-forward exemption the systemMode path
+    has.
+    """
+    config = {**CONFIG, "socMin": "30", "dischargeProtection": "12"}
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(config)],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(soc_max=90))
+
+    assert len(session.calls_to("socLimit")) == 1
+
+
+def test_set_soc_limit_re_reads_even_when_given_both_bounds():
+    """This used to skip the GET when nothing had to be filled in.
+
+    That optimisation is what let the shipped SOC Minimum entity write a floor
+    the discharge-protection guard would have refused: the guard needs the
+    current dischargeProtection, which only the config carries. One GET is
+    cheaper than a rule that holds on one write path and not its twin.
+    """
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
         "socLimit": [ok({"flag": True})],
     })
     api = make_api(session)
 
     asyncio.run(api.async_set_soc_limit(20, 95))
 
-    assert session.calls_to("systemMode") == []
+    assert len(session.calls_to("systemMode")) == 1
+    assert len(session.calls_to("socLimit")) == 1
 
 
 def test_set_soc_limit_fetches_the_omitted_bound():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -34,6 +34,18 @@ class FakeResponse:
         return self._body
 
 
+class UnparsableResponse(FakeResponse):
+    """A response whose body isn't JSON -- e.g. an HTML error page from a
+    gateway/WAF in front of the API, which routinely happens on 401/403/502."""
+
+    def __init__(self, status: int):
+        super().__init__(status, body={})
+
+    async def json(self, content_type=None):
+        self.json_calls += 1
+        raise ValueError("not JSON")
+
+
 class FakeSession:
     """Scripted stand-in for aiohttp.ClientSession.
 
@@ -157,6 +169,20 @@ def test_dead_refresh_token_raises_auth_error():
     # A dead refresh_token must short-circuit before ever touching the
     # actual endpoint.
     assert session.calls_to("systemMode") == []
+
+
+def test_dead_refresh_token_with_unparsable_body_raises_auth_error():
+    """Gateways/WAFs routinely return an HTML error page, not JSON, for a 401
+    or 403. The status check must still run even when the body can't be
+    parsed -- otherwise the ValueError gets swallowed by the broad transport
+    catch and the caller never learns the credentials are dead."""
+    session = FakeSession({
+        "refreshToken": [UnparsableResponse(401)],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(api.async_get_config())
 
 
 def test_cached_token_is_reused():

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -101,7 +101,9 @@ def test_bootstrap_refresh_precedes_first_call():
     assert refreshes[0]["headers"]["Authorization"] == "Bearer BOOTSTRAP"
     assert refreshes[0]["data"]["refresh_token"] == "RT-UUID"
     # ...and the actual call uses the fresh one.
-    assert session.calls_to("systemMode")[0]["headers"]["Authorization"] == "Bearer JWT-1"
+    gets = session.calls_to("systemMode")
+    assert len(gets) == 1
+    assert gets[0]["headers"]["Authorization"] == "Bearer JWT-1"
 
 
 def test_401_triggers_exactly_one_refresh_and_retry():
@@ -147,6 +149,10 @@ def test_dead_refresh_token_raises_auth_error():
 
     with pytest.raises(cloud.EzhiCloudAuthError):
         asyncio.run(api.async_get_config())
+
+    # A dead refresh_token must short-circuit before ever touching the
+    # actual endpoint.
+    assert session.calls_to("systemMode") == []
 
 
 def test_cached_token_is_reused():
@@ -252,7 +258,9 @@ def test_turn_on_sends_status_zero():
 
     asyncio.run(api.async_set_on_off(True))
 
-    call = session.calls_to("onOff")[0]
+    calls = session.calls_to("onOff")
+    assert len(calls) == 1
+    call = calls[0]
     assert call["method"] == "POST"
     assert call["url"].endswith("/remote/ezInverter/onOff/D02000000577")
     assert call["data"]["status"] == "0"
@@ -267,7 +275,9 @@ def test_turn_off_sends_status_one():
 
     asyncio.run(api.async_set_on_off(False))
 
-    assert session.calls_to("onOff")[0]["data"]["status"] == "1"
+    calls = session.calls_to("onOff")
+    assert len(calls) == 1
+    assert calls[0]["data"]["status"] == "1"
 
 
 def test_turn_on_while_offline_raises_offline_error():
@@ -336,9 +346,10 @@ def test_set_soc_limit_sends_both_bounds():
 
     asyncio.run(api.async_set_soc_limit(20, 95))
 
-    call = session.calls_to("socLimit")[0]
-    assert call["data"]["socMin"] == "20"
-    assert call["data"]["socMax"] == "95"
+    calls = session.calls_to("socLimit")
+    assert len(calls) == 1
+    assert calls[0]["data"]["socMin"] == "20"
+    assert calls[0]["data"]["socMax"] == "95"
 
 
 def test_rejected_write_raises():
@@ -369,3 +380,44 @@ def test_set_soc_limit_rejects_implausible_bounds():
         asyncio.run(api.async_set_soc_limit(95, 20))
 
     assert session.calls == []
+
+
+def test_concurrent_first_calls_trigger_exactly_one_refresh():
+    """Two callers racing on an unrefreshed token must not both refresh --
+    this is the declared risk area for the double-checked locking in
+    _ensure_token, and was previously only exercised sequentially."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+    })
+    api = make_api(session)
+
+    async def both():
+        return await asyncio.gather(
+            api.async_get_config(), api.async_get_config()
+        )
+
+    results = asyncio.run(both())
+
+    assert results == [CONFIG, CONFIG]
+    assert len(session.calls_to("refreshToken")) == 1
+    assert len(session.calls_to("systemMode")) == 2
+
+
+def test_get_config_uses_deviceId_type_language_params():
+    """Pin the systemMode GET parameter shape -- the plan's one declared open
+    guess (docs/ezhi-cloud-api-map.md doesn't capture the query params). If
+    Task 5's live probe finds a different shape, this test must be the thing
+    that changes, deliberately."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_get_config())
+
+    call = session.calls_to("systemMode")[0]
+    assert call["params"] == {
+        "deviceId": "D02000000577", "type": "EZHI", "language": "en",
+    }

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1075,3 +1075,96 @@ def test_setting_power_limit_explicitly_still_sends_it():
     asyncio.run(api.async_set_system_mode(powerLimit=800))
 
     assert _system_mode_params(session)["powerLimit"] == "800"
+
+
+# --- high power mode ----------------------------------------------------
+
+SCHEDULE_50W = [{"weekly": ["MON"], "strategy": ["07000021000020050"]}]
+SCHEDULE_1000W = [{"weekly": ["MON"], "strategy": ["07000021000021000"]}]
+
+
+def test_schedule_powers_decode_the_trailing_watts():
+    """"07000021000020050" is 07:00:00-21:00:00, mode 2, 50 W."""
+    assert cloud.weekly_schedule_powers(
+        {"outputPowerStrategyWeekly": SCHEDULE_50W}) == [50]
+    assert cloud.weekly_schedule_powers(
+        {"outputPowerStrategyWeekly": SCHEDULE_1000W}) == [1000]
+
+
+def test_schedule_powers_tolerate_junk_instead_of_guessing():
+    """A string that doesn't fit the shape is skipped, not misread."""
+    config = {"outputPowerStrategyWeekly": [
+        {"strategy": ["nonsense", "", None]},
+        {"no_strategy_key": 1},
+        "not even a dict",
+    ]}
+    assert cloud.weekly_schedule_powers(config) == []
+    assert cloud.weekly_schedule_powers({}) == []
+
+
+def test_high_power_on_writes_1200():
+    session = _mode_session({**CONFIG, "powerLimit": "800"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_high_power(True))
+
+    assert _system_mode_params(session)["powerLimit"] == "1200"
+
+
+def test_high_power_off_writes_800():
+    session = _mode_session({**CONFIG, "powerLimit": "1200"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_high_power(False))
+
+    assert _system_mode_params(session)["powerLimit"] == "800"
+
+
+def test_lowering_the_limit_under_a_schedule_entry_is_refused():
+    """Never silently rewrite a schedule as a side effect of another setting."""
+    session = _mode_session({
+        **CONFIG, "powerLimit": "1200",
+        "outputPowerStrategyWeekly": SCHEDULE_1000W,
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="1000 W"):
+        asyncio.run(api.async_set_high_power(False))
+
+    assert [c for c in session.calls_to("systemMode") if c["method"] == "POST"] == []
+
+
+def test_lowering_the_limit_over_a_small_schedule_entry_is_fine():
+    session = _mode_session({
+        **CONFIG, "powerLimit": "1200",
+        "outputPowerStrategyWeekly": SCHEDULE_50W,
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_high_power(False))
+
+    assert _system_mode_params(session)["powerLimit"] == "800"
+
+
+def test_raising_the_limit_is_never_blocked_by_the_schedule():
+    """The guard is about lowering below an entry, not about the schedule
+    existing at all."""
+    session = _mode_session({
+        **CONFIG, "powerLimit": "800",
+        "outputPowerStrategyWeekly": SCHEDULE_1000W,
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_high_power(True))
+
+    assert _system_mode_params(session)["powerLimit"] == "1200"
+
+
+def test_the_schedule_itself_is_never_written_back():
+    """It is a list; wire_str would send it as str(list)."""
+    session = _mode_session({**CONFIG, "outputPowerStrategyWeekly": SCHEDULE_50W})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_high_power(True))
+
+    assert "outputPowerStrategyWeekly" not in _system_mode_params(session)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -46,6 +46,10 @@ class FakeSession:
         self.calls: list[dict] = []
 
     async def request(self, method, url, params=None, data=None, headers=None):
+        # Yield to the event loop so concurrent callers actually interleave --
+        # without this a "concurrent" test runs strictly sequentially and would
+        # pass even with the double-checked locking removed.
+        await asyncio.sleep(0)
         self.calls.append(
             {"method": method, "url": url, "params": params, "data": data,
              "headers": headers}

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -281,6 +281,24 @@ def test_turn_on_while_offline_raises_offline_error():
     with pytest.raises(cloud.EzhiCloudOfflineError):
         asyncio.run(api.async_set_on_off(True))
 
+    assert len(session.calls_to("onOff")) == 1
+
+
+def test_turn_off_rejection_raises_plain_error_not_offline():
+    """The offline diagnosis (with its concrete, possibly wrong battery-button
+    advice) is only valid for a failed ON attempt with reason:1. A rejected
+    OFF must not be misdiagnosed as the device being offline."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": False, "reason": 7})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError) as exc_info:
+        asyncio.run(api.async_set_on_off(False))
+
+    assert not isinstance(exc_info.value, cloud.EzhiCloudOfflineError)
+
 
 def test_set_system_mode_posts_full_params_json():
     session = FakeSession({

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -272,6 +272,20 @@ def test_programming_error_propagates_unwrapped():
         asyncio.run(api.async_get_config())
 
 
+def test_timeout_error_message_names_the_budget():
+    """A bare 'transport failure talking to the EZHI cloud: TimeoutError()'
+    doesn't tell the user we gave up after N seconds -- name the configured
+    timeout budget specifically for this case."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [TimeoutError("timed out")],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="15"):
+        asyncio.run(api.async_get_config())
+
+
 def test_build_params_carries_untouched_fields_forward():
     """A mode switch must not silently drop the EPS/backup release."""
     params = cloud.build_system_mode_params(CONFIG, systemMode="4")

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -184,3 +184,89 @@ def test_build_params_fails_loud_on_incomplete_config():
     with pytest.raises(cloud.EzhiCloudError, match="EPS"):
         cloud.build_system_mode_params({"systemMode": "2", "ECO": "0",
                                         "userSetPower": "200"})
+
+
+def test_turn_on_sends_status_zero():
+    """status=0 turns the inverter ON. Inverted, and verified in the capture."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_on_off(True))
+
+    call = session.calls_to("onOff")[0]
+    assert call["method"] == "POST"
+    assert call["url"].endswith("/remote/ezInverter/onOff/D02000000577")
+    assert call["data"]["status"] == "0"
+
+
+def test_turn_off_sends_status_one():
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_on_off(False))
+
+    assert session.calls_to("onOff")[0]["data"]["status"] == "1"
+
+
+def test_turn_on_while_offline_raises_offline_error():
+    """flag:false + reason:1 -> the cloud cannot wake a powered-down inverter."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": False, "reason": 1})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudOfflineError):
+        asyncio.run(api.async_set_on_off(True))
+
+
+def test_set_system_mode_posts_full_params_json():
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(CONFIG, systemMode="4"))
+
+    call = session.calls_to("systemMode")[0]
+    assert call["method"] == "POST"
+    assert call["data"]["deviceId"] == "D02000000577"
+    assert call["data"]["identifierType"] == "1"
+    assert call["data"]["maxPowerFlag"] == "0"
+    assert json.loads(call["data"]["params"]) == {
+        "systemMode": "4", "EPS": "1", "ECO": "0", "userSetPower": "200",
+    }
+
+
+def test_set_soc_limit_sends_both_bounds():
+    """The socLimit endpoint takes both bounds, so both always travel."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "socLimit": [ok({"flag": True})],
+    })
+    api = make_api(session)
+
+    asyncio.run(api.async_set_soc_limit(20, 95))
+
+    call = session.calls_to("socLimit")[0]
+    assert call["data"]["socMin"] == "20"
+    assert call["data"]["socMax"] == "95"
+
+
+def test_rejected_write_raises():
+    """flag:false is a failure, never a success."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "socLimit": [ok({"flag": False})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_set_soc_limit(20, 95))

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -157,3 +157,30 @@ def test_cached_token_is_reused():
 
     assert len(session.calls_to("refreshToken")) == 1
     assert len(session.calls_to("systemMode")) == 2
+
+
+def test_build_params_carries_untouched_fields_forward():
+    """A mode switch must not silently drop the EPS/backup release."""
+    params = cloud.build_system_mode_params(CONFIG, systemMode="4")
+
+    assert params == {
+        "systemMode": "4", "EPS": "1", "ECO": "0", "userSetPower": "200",
+    }
+
+
+def test_build_params_stringifies_and_ignores_extra_config_keys():
+    config = {"systemMode": 2, "EPS": 1, "ECO": 0, "userSetPower": 200,
+              "socMin": 10, "powerLimit": 1200}
+
+    params = cloud.build_system_mode_params(config)
+
+    assert params == {
+        "systemMode": "2", "EPS": "1", "ECO": "0", "userSetPower": "200",
+    }
+
+
+def test_build_params_fails_loud_on_incomplete_config():
+    """Never guess a default for a field that drives real hardware."""
+    with pytest.raises(cloud.EzhiCloudError, match="EPS"):
+        cloud.build_system_mode_params({"systemMode": "2", "ECO": "0",
+                                        "userSetPower": "200"})

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -227,6 +227,21 @@ def test_build_params_fails_loud_on_incomplete_config():
                                         "userSetPower": "200"})
 
 
+def test_build_params_rejects_unknown_kwargs():
+    """A typo like `systemmode=` must not sail through as a silent no-op."""
+    with pytest.raises(cloud.EzhiCloudError, match="systemmode"):
+        cloud.build_system_mode_params(CONFIG, systemmode="4")
+
+
+def test_build_params_normalises_bool_to_wire_string():
+    """str(True) is "True" -- the cloud expects "1"/"0"."""
+    config = {"systemMode": "2", "EPS": True, "ECO": "0", "userSetPower": "200"}
+
+    params = cloud.build_system_mode_params(config)
+
+    assert params["EPS"] == "1"
+
+
 def test_turn_on_sends_status_zero():
     """status=0 turns the inverter ON. Inverted, and verified in the capture."""
     session = FakeSession({

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -346,8 +346,10 @@ def test_turn_off_sends_status_one():
     assert calls[0]["data"]["status"] == "1"
 
 
-def test_turn_on_while_offline_raises_offline_error():
-    """flag:false + reason:1 -> the cloud cannot wake a powered-down inverter."""
+def test_turn_on_with_reason_1_raises_offline_error():
+    """on=True, reason:1 -> the cloud cannot wake a powered-down inverter.
+    reason:1 means offline regardless of direction; the ON case also gets
+    the concrete battery-button advice."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
         "onOff": [ok({"flag": False, "reason": 1})],
@@ -360,10 +362,41 @@ def test_turn_on_while_offline_raises_offline_error():
     assert len(session.calls_to("onOff")) == 1
 
 
-def test_turn_off_rejection_raises_plain_error_not_offline():
-    """The offline diagnosis (with its concrete, possibly wrong battery-button
-    advice) is only valid for a failed ON attempt with reason:1. A rejected
-    OFF must not be misdiagnosed as the device being offline."""
+def test_turn_on_with_other_reason_raises_plain_error():
+    """on=True, reason:7 (not 1) -> a rejection for some other reason is not
+    an offline diagnosis."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": False, "reason": 7})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError) as exc_info:
+        asyncio.run(api.async_set_on_off(True))
+
+    assert not isinstance(exc_info.value, cloud.EzhiCloudOfflineError)
+
+
+def test_turn_off_with_reason_1_raises_offline_error():
+    """on=False, reason:1 -> offline is about reachability, not direction. If
+    the inverter is offline and OFF is sent, it will likely also answer
+    reason:1 -- a caller that handles offline specially must still see it,
+    just without the ON-specific battery-button advice."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "onOff": [ok({"flag": False, "reason": 1})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudOfflineError):
+        asyncio.run(api.async_set_on_off(False))
+
+    assert len(session.calls_to("onOff")) == 1
+
+
+def test_turn_off_with_other_reason_raises_plain_error():
+    """on=False, reason:7 (not 1) -> a rejected OFF for some other reason
+    must not be misdiagnosed as the device being offline."""
     session = FakeSession({
         "refreshToken": [ok({"access_token": "JWT-1"})],
         "onOff": [ok({"flag": False, "reason": 7})],

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -910,3 +910,168 @@ def test_get_config_uses_deviceId_type_language_params():
     assert call["params"] == {
         "deviceId": "D02000000577", "type": "EZHI", "language": "en",
     }
+
+
+# --- ECO/EPS interlock -------------------------------------------------
+#
+# The firmware rejects ECO=1 together with EPS=1. switch.py cannot be tested
+# here (no HA harness), so the pairing lives in cloud.py and is pinned below.
+
+
+def _system_mode_params(session):
+    """The params blob of the one systemMode POST the session recorded."""
+    posts = [c for c in session.calls_to("systemMode") if c["method"] == "POST"]
+    assert len(posts) == 1, f"expected exactly one POST, got {len(posts)}"
+    return json.loads(posts[0]["data"]["params"])
+
+
+def _mode_session(config=None):
+    return FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        # First call is the read-modify-write GET, second the POST.
+        "systemMode": [ok(config or CONFIG), ok({"flag": True})],
+    })
+
+
+def test_enabling_backup_power_clears_eco_in_the_same_write():
+    """EPS=1 and ECO=1 together is a state the device rejects."""
+    session = _mode_session({**CONFIG, "EPS": "0", "ECO": "1"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_backup_power(True))
+
+    params = _system_mode_params(session)
+    assert params["EPS"] == "1"
+    assert params["ECO"] == "0"
+
+
+def test_disabling_backup_power_does_not_enable_eco():
+    """Off is off -- not "switch to the other one"."""
+    session = _mode_session({**CONFIG, "EPS": "1", "ECO": "0"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_backup_power(False))
+
+    params = _system_mode_params(session)
+    assert params["EPS"] == "0"
+    assert params["ECO"] == "0"
+
+
+def test_enabling_eco_clears_backup_power_in_the_same_write():
+    session = _mode_session({**CONFIG, "EPS": "1", "ECO": "0"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_eco(True))
+
+    params = _system_mode_params(session)
+    assert params["ECO"] == "1"
+    assert params["EPS"] == "0"
+
+
+def test_disabling_eco_does_not_enable_backup_power():
+    session = _mode_session({**CONFIG, "EPS": "0", "ECO": "1"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_eco(False))
+
+    params = _system_mode_params(session)
+    assert params["ECO"] == "0"
+    assert params["EPS"] == "0"
+
+
+# --- discharge protection floor ----------------------------------------
+
+
+def test_discharge_protection_below_soc_min_plus_margin_is_refused():
+    """The app enforces socMin+2; this write path is the only other way in."""
+    session = _mode_session({**CONFIG, "socMin": "10", "dischargeProtection": "12"})
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError, match="at least"):
+        asyncio.run(api.async_set_system_mode(dischargeProtection=11))
+
+    assert [c for c in session.calls_to("systemMode") if c["method"] == "POST"] == []
+
+
+def test_discharge_protection_exactly_at_the_margin_is_allowed():
+    session = _mode_session({**CONFIG, "socMin": "10", "dischargeProtection": "20"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(dischargeProtection=12))
+
+    assert _system_mode_params(session)["dischargeProtection"] == "12"
+
+
+def test_a_plain_mode_switch_is_not_blocked_by_a_preexisting_bad_floor():
+    """Never refuse a write over a value the caller did not set."""
+    session = _mode_session({**CONFIG, "socMin": "50", "dischargeProtection": "12"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(systemMode="4"))
+
+    assert _system_mode_params(session)["systemMode"] == "4"
+
+
+def test_lowering_soc_min_under_the_floor_is_also_checked():
+    """The rule couples two fields, so moving either one has to be checked."""
+    session = _mode_session({**CONFIG, "socMin": "10", "dischargeProtection": "12"})
+    api = make_api(session)
+
+    # socMin 11 would leave the existing floor of 12 only 1% above it.
+    with pytest.raises(cloud.EzhiCloudError, match="at least"):
+        asyncio.run(api.async_set_system_mode(socMin=11))
+
+
+# --- the widened write vocabulary --------------------------------------
+
+
+def test_power_limit_is_a_settable_system_mode_field():
+    """powerLimit needs no separate endpoint -- it is a params field."""
+    session = _mode_session()
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(powerLimit=800))
+
+    assert _system_mode_params(session)["powerLimit"] == "800"
+
+
+def test_schedule_lists_are_not_carried_forward():
+    """wire_str would turn a schedule into str(list) and corrupt it."""
+    assert "outputPowerStrategyWeekly" not in cloud.SYSTEM_MODE_OPTIONAL_KEYS
+    assert "outputPowerStrategy" not in cloud.SYSTEM_MODE_OPTIONAL_KEYS
+
+    config = {**CONFIG, "outputPowerStrategyWeekly": [{"weekly": ["MON"]}]}
+    params = cloud.build_system_mode_params(config, systemMode="4")
+    assert "outputPowerStrategyWeekly" not in params
+
+
+def test_a_typo_in_a_field_name_is_still_refused():
+    """Widening the vocabulary must not turn typos into silent no-ops."""
+    with pytest.raises(cloud.EzhiCloudError, match="unknown"):
+        cloud.build_system_mode_params(CONFIG, powerLimits=800)
+
+
+def test_power_limit_is_not_carried_forward_into_an_unrelated_write():
+    """The regression this category was created for.
+
+    The POST hardcodes maxPowerFlag="0", and the device only allows a limit
+    above 800 W while high-power mode is on. Re-asserting a live 1200 under
+    that flag risks the device clamping it -- so a mode switch must not send
+    powerLimit at all unless the caller set it.
+    """
+    session = _mode_session({**CONFIG, "powerLimit": "1200"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(systemMode="4"))
+
+    assert "powerLimit" not in _system_mode_params(session)
+
+
+def test_setting_power_limit_explicitly_still_sends_it():
+    """Not carried forward is not the same as not settable."""
+    session = _mode_session({**CONFIG, "powerLimit": "1200"})
+    api = make_api(session)
+
+    asyncio.run(api.async_set_system_mode(powerLimit=800))
+
+    assert _system_mode_params(session)["powerLimit"] == "800"

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,0 +1,159 @@
+"""Unit tests for the EZHI cloud client.
+
+No network, no Home Assistant: cloud.py is loaded by path and driven with a
+scripted fake aiohttp session.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "apsystems_ezhi_local"
+    / "cloud.py"
+)
+_spec = importlib.util.spec_from_file_location("ezhi_cloud", _MODULE_PATH)
+cloud = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cloud)
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self._body = body
+
+    async def json(self, content_type=None):
+        return self._body
+
+
+class FakeSession:
+    """Scripted stand-in for aiohttp.ClientSession.
+
+    `script` maps a URL substring to a list of FakeResponse. Each match pops the
+    next response; the last one repeats forever.
+    """
+
+    def __init__(self, script: dict[str, list[FakeResponse]]):
+        self.script = script
+        self.calls: list[dict] = []
+
+    async def request(self, method, url, params=None, data=None, headers=None):
+        self.calls.append(
+            {"method": method, "url": url, "params": params, "data": data,
+             "headers": headers}
+        )
+        for key, queue in self.script.items():
+            if key in url:
+                return queue.pop(0) if len(queue) > 1 else queue[0]
+        raise AssertionError(f"unscripted call: {method} {url}")
+
+    def calls_to(self, needle: str) -> list[dict]:
+        return [c for c in self.calls if needle in c["url"]]
+
+
+def ok(data: dict) -> FakeResponse:
+    return FakeResponse(200, {"code": 0, "data": data})
+
+
+def make_api(session, **kwargs):
+    defaults = dict(
+        device_id="D02000000577",
+        access_token="BOOTSTRAP",
+        refresh_token="RT-UUID",
+    )
+    defaults.update(kwargs)
+    return cloud.EzhiCloudApi(session=session, **defaults)
+
+
+CONFIG = {
+    "systemMode": "2", "EPS": "1", "ECO": "0", "userSetPower": "200",
+    "socMin": "10", "socMax": "100", "onOff": "0", "powerLimit": "1200",
+}
+
+
+def test_bootstrap_refresh_precedes_first_call():
+    """The very first API call must fetch a token, using the bootstrap bearer."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+    })
+    api = make_api(session)
+
+    result = asyncio.run(api.async_get_config())
+
+    assert result == CONFIG
+    refreshes = session.calls_to("refreshToken")
+    assert len(refreshes) == 1
+    # The refresh authenticates with the (possibly expired) bootstrap token...
+    assert refreshes[0]["headers"]["Authorization"] == "Bearer BOOTSTRAP"
+    assert refreshes[0]["data"]["refresh_token"] == "RT-UUID"
+    # ...and the actual call uses the fresh one.
+    assert session.calls_to("systemMode")[0]["headers"]["Authorization"] == "Bearer JWT-1"
+
+
+def test_401_triggers_exactly_one_refresh_and_retry():
+    """A rejected token is refreshed once and the call retried once."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"}), ok({"access_token": "JWT-2"})],
+        "systemMode": [FakeResponse(401, {}), ok(CONFIG)],
+    })
+    api = make_api(session)
+
+    result = asyncio.run(api.async_get_config())
+
+    assert result == CONFIG
+    assert len(session.calls_to("refreshToken")) == 2   # bootstrap + after the 401
+    gets = session.calls_to("systemMode")
+    assert len(gets) == 2                                # original + one retry
+    assert gets[1]["headers"]["Authorization"] == "Bearer JWT-2"
+
+
+def test_second_401_is_not_retried_again():
+    """One retry, not a loop."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [FakeResponse(401, {})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudError):
+        asyncio.run(api.async_get_config())
+
+    assert len(session.calls_to("systemMode")) == 2
+
+
+def test_dead_refresh_token_raises_auth_error():
+    """Codes 3000-3004 mean the refresh_token itself is gone."""
+    session = FakeSession({
+        "refreshToken": [FakeResponse(200, {"code": 3001, "message": "token expired"})],
+    })
+    api = make_api(session)
+
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(api.async_get_config())
+
+
+def test_cached_token_is_reused():
+    """A second call inside the TTL must not refresh again."""
+    session = FakeSession({
+        "refreshToken": [ok({"access_token": "JWT-1"})],
+        "systemMode": [ok(CONFIG)],
+    })
+    api = make_api(session)
+
+    async def two_calls():
+        # One event loop for both: the api holds an asyncio.Lock, which must not
+        # be carried across loops.
+        await api.async_get_config()
+        await api.async_get_config()
+
+    asyncio.run(two_calls())
+
+    assert len(session.calls_to("refreshToken")) == 1
+    assert len(session.calls_to("systemMode")) == 2

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -63,8 +63,13 @@ def _decrypt(hex_text: str, key: str = KEY, iv: str = IV) -> bytes:
 # --- the crypto -------------------------------------------------------------
 
 def test_aes_matches_the_app_for_fixed_vectors():
-    assert cloud._aes_hex("user@example.invalid", KEY, IV) == (
-        "2d2b2ac01699ee69f798cfbe603054dd54ad7af7f5fb6b9c2eaff9a1618f9b7d"
+    assert cloud._aes_hex("ema-user", KEY, IV) == (
+        "55bdd58f4323f5571b40e33abe21fd1f"
+    )
+    # Spans two blocks, so a broken chaining mode shows up here and not only
+    # in the single-block case.
+    assert cloud._aes_hex("ema-user-0123456789", KEY, IV) == (
+        "d21baa59bcdcc0fcdd5bec2de6fb5a455c580699dbeae027a31129cdc86c0fe4"
     )
     assert cloud._aes_hex("hunter2", KEY, IV) == "d6473094b52dc1e8b822ce7615e3d399"
 
@@ -88,7 +93,7 @@ def test_rsa_wraps_the_key_under_the_apps_public_key():
 
 
 def test_login_params_carry_the_app_constants_and_no_plaintext():
-    params = cloud.build_login_params("user@example.invalid", "hunter2",
+    params = cloud.build_login_params("ema-user", "hunter2",
                                       key=KEY, iv=IV)
     assert params["app_id"] == cloud.LOGIN_APP_ID
     assert params["app_secret"] == cloud.LOGIN_APP_SECRET
@@ -96,7 +101,7 @@ def test_login_params_carry_the_app_constants_and_no_plaintext():
                            "username", "password"}
     # The whole point: neither credential travels readable.
     blob = "".join(params.values())
-    assert "hunter2" not in blob and "user@example.invalid" not in blob
+    assert "hunter2" not in blob and "ema-user" not in blob
     assert _decrypt(params["password"]).rstrip(b"\0") == b"hunter2"
 
 
@@ -117,7 +122,7 @@ def test_login_returns_the_token_pair():
     # Long enough not to collide with random base64 -- a two-letter needle
     # matches by chance and makes this assertion flaky rather than meaningful.
     secret = "correct-horse-battery-staple"
-    tokens = asyncio.run(cloud.async_login(session, "user@example.invalid", secret))
+    tokens = asyncio.run(cloud.async_login(session, "ema-user", secret))
 
     assert tokens == {"access_token": "JWT", "refresh_token": "UUID"}
     call = session.calls[0]

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,157 @@
+"""Unit tests for the loginEncrypt path.
+
+No network and no Home Assistant. The crypto is pinned against fixed key/IV
+vectors because every way of getting it wrong -- PKCS7 instead of the app's
+zero fill, the raw key bytes instead of their hex text, a rotated IV -- fails
+identically at runtime, as "wrong username or password".
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")  # ships with Home Assistant, not with bare python
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes  # noqa: E402
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "apsystems_ezhi_local"
+    / "cloud.py"
+)
+_spec = importlib.util.spec_from_file_location("ezhi_cloud_login", _MODULE_PATH)
+cloud = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cloud)
+
+KEY = "0123456789abcdef0123456789abcdef"   # 32 chars, as the app's hex text
+IV = "0000000000000042"                    # 16 chars, as the app's decimal text
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self._body = body
+
+    async def json(self, content_type=None):
+        return self._body
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def request(self, method, url, params=None, data=None, headers=None):
+        await asyncio.sleep(0)
+        self.calls.append({"method": method, "url": url, "data": data,
+                           "headers": headers})
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def _decrypt(hex_text: str, key: str = KEY, iv: str = IV) -> bytes:
+    decryptor = Cipher(algorithms.AES(key.encode()), modes.CBC(iv.encode())).decryptor()
+    raw = bytes.fromhex(hex_text)
+    return decryptor.update(raw) + decryptor.finalize()
+
+
+# --- the crypto -------------------------------------------------------------
+
+def test_aes_matches_the_app_for_fixed_vectors():
+    assert cloud._aes_hex("user@example.invalid", KEY, IV) == (
+        "2d2b2ac01699ee69f798cfbe603054dd54ad7af7f5fb6b9c2eaff9a1618f9b7d"
+    )
+    assert cloud._aes_hex("hunter2", KEY, IV) == "d6473094b52dc1e8b822ce7615e3d399"
+
+
+def test_padding_is_zero_fill_and_adds_a_whole_block_on_an_exact_fit():
+    """The app's rule, not PKCS7 -- and not "no padding when it already fits"."""
+    exact = "sixteen-chars-16"
+    assert len(exact) == 16
+    cipher = cloud._aes_hex(exact, KEY, IV)
+    assert len(bytes.fromhex(cipher)) == 32          # one block of payload, one of zeros
+    assert _decrypt(cipher) == exact.encode() + b"\0" * 16
+
+    short = "hunter2"
+    assert _decrypt(cloud._aes_hex(short, KEY, IV)) == short.encode() + b"\0" * 9
+
+
+def test_rsa_wraps_the_key_under_the_apps_public_key():
+    import base64
+    blob = base64.b64decode(cloud._rsa_b64(KEY))
+    assert len(blob) == 256                          # RSA-2048 block
+
+
+def test_login_params_carry_the_app_constants_and_no_plaintext():
+    params = cloud.build_login_params("user@example.invalid", "hunter2",
+                                      key=KEY, iv=IV)
+    assert params["app_id"] == cloud.LOGIN_APP_ID
+    assert params["app_secret"] == cloud.LOGIN_APP_SECRET
+    assert set(params) == {"app_id", "app_secret", "key", "version",
+                           "username", "password"}
+    # The whole point: neither credential travels readable.
+    blob = "".join(params.values())
+    assert "hunter2" not in blob and "user@example.invalid" not in blob
+    assert _decrypt(params["password"]).rstrip(b"\0") == b"hunter2"
+
+
+def test_key_and_iv_are_drawn_fresh_per_login():
+    a = cloud.build_login_params("u", "p")
+    b = cloud.build_login_params("u", "p")
+    # Same credentials, different ciphertext -- a fixed key would make the
+    # captured request replayable.
+    assert a["username"] != b["username"]
+    assert a["key"] != b["key"]
+
+
+# --- the request ------------------------------------------------------------
+
+def test_login_returns_the_token_pair():
+    session = FakeSession(FakeResponse(200, {"code": 0, "data": {
+        "user_id": "u1", "access_token": "JWT", "refresh_token": "UUID"}}))
+    # Long enough not to collide with random base64 -- a two-letter needle
+    # matches by chance and makes this assertion flaky rather than meaningful.
+    secret = "correct-horse-battery-staple"
+    tokens = asyncio.run(cloud.async_login(session, "user@example.invalid", secret))
+
+    assert tokens == {"access_token": "JWT", "refresh_token": "UUID"}
+    call = session.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"] == cloud.LOGIN_URL
+    assert call["data"]["language"] == "en"
+    assert "Authorization" not in call["headers"]     # nothing to authorise with yet
+    assert secret not in "".join(map(str, call["data"].values()))
+
+
+def test_bad_credentials_raise_auth_not_a_generic_error():
+    session = FakeSession(FakeResponse(200, {"code": 2006, "message": "nope"}))
+    with pytest.raises(cloud.EzhiCloudAuthError) as err:
+        asyncio.run(cloud.async_login(session, "u", "wrong"))
+    assert "2006" in str(err.value)
+
+
+def test_a_sick_cloud_is_not_reported_as_a_bad_password():
+    """A 502 must not send the user off to reset a password that was fine."""
+    session = FakeSession(FakeResponse(502, {}))
+    with pytest.raises(cloud.EzhiCloudError) as err:
+        asyncio.run(cloud.async_login(session, "u", "p"))
+    assert not isinstance(err.value, cloud.EzhiCloudAuthError)
+    assert "502" in str(err.value)
+
+
+def test_a_success_without_tokens_is_still_a_failure():
+    session = FakeSession(FakeResponse(200, {"code": 0, "data": {"user_id": "u1"}}))
+    with pytest.raises(cloud.EzhiCloudAuthError):
+        asyncio.run(cloud.async_login(session, "u", "p"))
+
+
+def test_transport_failure_is_wrapped_with_the_url():
+    session = FakeSession(OSError("connection reset"))
+    with pytest.raises(cloud.EzhiCloudError) as err:
+        asyncio.run(cloud.async_login(session, "u", "p"))
+    assert "loginEncrypt" in str(err.value)


### PR DESCRIPTION
Adds optional cloud control to the integration. On/off, system mode and **backup power (EPS)** are not in the local API at all — they exist only in the APsystems EMA cloud, which is why the integration currently cannot expose them.

Everything here is opt-in: leave the two token fields empty and nothing about the integration changes.

## The design constraint

**A cloud failure must never take the local sensors down.** That is the whole architecture:

- a second, independent `DataUpdateCoordinator` — the local one is untouched
- `async_refresh()` at setup, not `async_config_entry_first_refresh()`, so a dead cloud cannot raise `ConfigEntryNotReady` and tear down the entry
- the startup refresh is deadlined at 20 s so a hanging cloud cannot delay local sensors
- `EzhiCloudAuthError` → `ConfigEntryAuthFailed` → reauth prompt; everything else → `UpdateFailed`
- platforms return early when no cloud credentials are configured

Verified on a live install: with a deliberately broken refresh token, all four cloud entities went `unavailable` and a reauth flow started, while all 130 local entities kept updating. With the network cut, setup finished in 0.01 s; with a hanging cloud, in 15.0 s.

## What it adds

| Entity | Type |
|--------|------|
| Inverter On | `switch` |
| System Mode | `select` (Balcony Storage, Portable, AI, Local, No Battery) |
| Backup Power (EPS) | `switch` |
| ECO Mode | `switch` |
| SOC Minimum / Maximum | `number` |
| Discharge Protection | `number` |
| Preset Output Power | `number` |
| Power Limit | `sensor`, read-only |

Plus a `set_high_power_mode` action, and a reauth flow.

Both actions take an optional `device_id`. With one inverter it can be omitted; with several set up, a call that does not name one is refused rather than answered by whichever entry happened to load last.

## Things that are not obvious, and are handled

- **`onOff` is inverted.** The field reads `"0"` while the inverter is *running*. `status=0` turns it on.
- **Turning the inverter off is one-way from HA.** Once down it drops off the cloud's MQTT link, so it needs PV/DC input or a 3 s press on the battery button. The switch uses `assumed_state` so it renders as two deliberate buttons rather than a toggle you can brush by accident.
- **ECO and EPS are mutually exclusive** in firmware — `ECO=1` forces `EPS=0`. Both always travel in one write, so the pair can never be observed in a state the device rejects.
- **The `systemMode` POST merges**, it does not replace. Confirmed two ways: the vendor app sends a different partial field set per mode (mode 4 sends only `systemMode`/`stayOn`/`thirdLink`), which under replace semantics would wipe SOC bounds and EPS on every mode switch in the app itself; and a live mode-4 write left every other field untouched.
- **The `/api/v2` path segment is mandatory.** Without it every endpoint answers HTTP 200 with body code 4 "Internal Server Error" — not a 404. A wrong path therefore looks exactly like a cloud outage. Pinned by a test.
- **ECO does not reduce standby draw.** A/B measured at ~17 W either way. It only powers down the off-grid output when nothing draws from it. Documented so nobody re-derives it.

## Two writes are refused rather than passed on

- **"No Battery" mode while a battery is connected** — the "battery access conflict" the vendor app warns about. The refusal lifts by itself once the cloud stops reporting a battery, so there is no override flag to leave switched on.
- **Discharge protection below `socMin + 2`** — the same rule the app enforces; otherwise the device clamps it silently.

## Two things that can override an entity, documented rather than hidden

Both are readable in the cloud config and neither has a write path I could find, so the README says so plainly instead of letting a number look authoritative:

- **`winter`** — ~~the app's "winter adaptive" button, which lifts the effective SOC floor to 50 % and discharge protection to 65 % without changing `socMin`~~. **Corrected after merge:** that was an inference, not a measurement, and it was wrong. The daily SOC minima on the development install scatter from 52 % to 83 % over 45 days — a battery that stopped being discharged, not one hitting a floor. And the app's text claims discharge protection rises to 65 %, while that install reached 52 % with `winter` set to 1. The translations are real, but no screen uses them: `winterMode` appears in the twelve language bundles and in no component, and the field is never read or written by the app — which is why it cannot be found in the UI. Treat the flag as inert or unimplemented. Fixed in the README on `main`.
- **`outputPowerStrategyWeekly`** — read to guard the power limit, never written. Worth noting that `isOPStrategy: 1` does not mean the schedule is in effect: in Local mode it is inert, measured at 1125 W output inside a window the schedule caps at 50 W.

## Why high power mode is an action, not a switch

Raising the ceiling from 800 W to 1200 W carries the vendor's own disclaimer: it "may cause the device output to exceed regulatory limits for grid connection", with the legal risk on the operator. Home Assistant has no confirmation dialog for an entity — a switch is always one tap — so it is an action with an `acknowledge_regulatory_risk` field, required only in the direction that carries the risk. The current value is visible as a read-only sensor.

Lowering the ceiling is refused while the weekly output schedule still has entries above it. The vendor app silently rewrites those entries; this does not — a schedule the user built is not ours to rewrite as a side effect of a different setting.

## Credentials: username and password, no proxy capture

The first version of this PR asked users to run an HTTPS proxy against the app. That is not a setup most people will complete, so it is gone.

The app encrypts credentials client-side — which is *why* a capture was needed — but the scheme is in the app's own implementation: a fresh AES-256 key and IV per login, both RSA-wrapped under a public key shipped in the app, credentials AES-CBC with a manual zero fill. Reproduced in `cloud.py`, so the config flow takes an account username and a password and mints the token pair itself. **The account username, not the e-mail address** — verified against a live account, and worth stating loudly because the rejection is indistinguishable from a wrong password. The field labels and the error message both name it. The password builds one request and is never stored or logged; only the tokens reach `entry.data`. The `refresh_token` does not rotate, so this has to work exactly once.

The two token fields still accept a captured pair for anyone who already has one.

Two things worth a maintainer's opinion:

- This ships the app's `app_id`/`app_secret` as constants. They are identical for every user and trivially extractable from the APK, but putting them in a public repo is your call, not mine.
- The crypto needs `cryptography`, which Home Assistant already depends on. It is imported inside the login functions so `cloud.py` still imports without it.

If the cloud layer is a blocker for merging at all, it can be split into a separate optional integration — happy to do that instead.

## What a review changed

An adversarial pass over the diff before opening this found two things worth naming, both the same shape — a rule that held on one write path and not on its twin:

- **The discharge-protection guard ran only on the `systemMode` path.** The shipped SOC Minimum entity writes through `socLimit`, which skipped it, so the entity could set a floor the vendor app refuses and the device then silently clamps. The guard's own docstring asserted this could not happen. Fixed, with the re-read made unconditional (the check needs the current floor) and two regression tests; verified against live hardware.
- **`hacs.json` claimed a minimum of 2023.5.0.** This branch uses `DataUpdateCoordinator(config_entry=…)` and `_get_reauth_entry()`, and on an older core the coordinator raises inside `async_setup_entry` — taking the local sensors down with it, which is precisely the isolation this PR is built around. Floor raised to 2024.11; the platform list in `hacs.json` also named three where five are set up.

Three smaller ones in the same pass: the read-modify-write paths now hold a lock across the GET-POST pair (setting SOC minimum and maximum back to back was enough to interleave them, with both reporting success), the no-battery guard no longer fails open when the cloud config omits the field, and the power-limit guard now says in a comment that it does not parse the daily `outputPowerStrategy`, whose watt encoding was never observed.

## Tests

88 unit tests for the cloud client, run with plain `pytest` — no network and no Home Assistant:

```
python3 -m pytest tests -q
```

`cloud.py` deliberately imports neither `homeassistant` nor `aiohttp` so it can be driven standalone by a scripted fake session. The 10 login-crypto tests need `cryptography` and skip cleanly without it, so a bare interpreter still runs the other 78.

## Example dashboard

`examples/` has one, in two variants with identical layout: `dashboard.yaml` using Mushroom and fold-entity-row, and `dashboard-core.yaml` using only cards Home Assistant ships with, so the example never depends on installing anything.

Every entity id in them is derived from the entity names in the source rather than copied off my install, and a check confirms both variants reference the same 44 entities and nothing else. That check is what caught the local grid-setpoint number missing entirely — it would otherwise have sat inside the cloud section readers are told to delete.

While writing it, one thing became hard to ignore: the id prefixes are not uniform. The local sensors are `sensor.ezhi_…`, while the cloud entities and the local power number carry an extra `apsystems_`, and the friendly names come out doubled (`EZHI APsystems EZHI Backup Power`) because `_attr_name` repeats the device name that `device_info` already carries. `_attr_has_entity_name = True` would fix both without changing existing entity ids. I have deliberately left that out of this PR — it touches entities this PR does not add, and it should be your call in its own change. Happy to send it separately.

## Not in this PR

- The three unmapped `getAlarm` fields — sent separately as #12, branched off `main` so the two PRs do not depend on each other. `BCI` there is the same conflict the "No Battery" guard above prevents.

## Compatibility

Additive only. No existing entity, unique ID or config key changes. `iot_class` stays `local_polling`, since that is what the integration is when the cloud layer is not configured.

---

Developed against a live EZHI 1.9.0.16 and running in production on Home Assistant 2026.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

