### PR TITLE
Map the three getAlarm fields that are currently ignored (BCC, BCI, VRP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Home Assistant integration allows you to monitor and control your APsystems
 - **Monitor PV Power & Energy**: Track photovoltaic power generation and total energy production.
 - **Battery Monitoring**: View battery state, charge/discharge rates, temperature, and status.
 - **Grid Interaction**: Monitor power flow to and from the grid.
-- **Alarm Monitoring**: Get notified about system errors and warnings via 17 binary sensors.
+- **Alarm Monitoring**: Get notified about system errors and warnings via 20 binary sensors.
 - **Power Control**: Set the maximum power output of your inverter.
 - **Separate Scan Intervals**: Configure fast polling for power data and slower polling for alarms/device info.
 - **Device Info Panel**: View firmware version, serial number, and direct link to inverter API.
@@ -103,6 +103,12 @@ After initial setup, you can change the scan intervals without reconfiguring:
 | PV Overcurrent | PV overcurrent protection active | PvOC |
 | PV Wiring Error | PV wiring error detected | PVWE |
 | IRD Error | IRD (Insulation Resistance Detection) error | IRDE |
+| SOC Calibration Needed | Battery SOC reading is off — charge to 100% to recalibrate | BCC |
+| Battery Access Conflict | A battery is connected while the inverter runs in battery-free mode | BCI |
+| Voltage Reset Protection | PV input too low, or protection after a grid anomaly/overload — a restart is needed and can take several minutes | VRP |
+
+The last three are reported by `getAlarm` on current firmware. On firmware that
+does not send them they read `unknown` rather than "no problem".
 
 ### Controls
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ Bruno API collection files are included for testing.
 
 ## Changelog
 
+### v0.3.0
+
+- **New:** three alarm sensors the local `getAlarm` endpoint reports but the
+  integration ignored — SOC Calibration Needed (`BCC`), Battery Access Conflict
+  (`BCI`) and Voltage Reset Protection (`VRP`)
+- On firmware that does not send them they read `unknown` rather than "no
+  problem", so an absent field is never reported as an all-clear
+- Manifest version corrected: it still said 0.2.0 while the changelog below
+  claimed 0.2.1, so HACS never saw that release
+
 ### v0.2.1
 
 - **New:** Added brand folder with icon.png and logo.png

--- a/custom_components/apsystems_ezhi_local/api.py
+++ b/custom_components/apsystems_ezhi_local/api.py
@@ -89,6 +89,12 @@ class ReturnAlarmData:
     IRDE: str    # IRD error
     PVWE: str    # PV wiring error
     OfGS: str    # Off grid short circuit
+    # Reported by getAlarm but previously unmapped. Default to "" rather than
+    # "0": firmware that does not send them should read as "unknown", not as a
+    # confident "no problem". BCI in particular is a safety-relevant claim.
+    BCC: str = ""   # SOC calibration needed
+    BCI: str = ""   # Battery access conflict
+    VRP: str = ""   # Voltage reset protection
 
 
 class APsystemsEZHI:
@@ -176,6 +182,9 @@ class APsystemsEZHI:
             IRDE=data.get("IRDE", "0"),
             PVWE=data.get("PVWE", "0"),
             OfGS=data.get("OfGS", "0"),
+            BCC=data.get("BCC", ""),
+            BCI=data.get("BCI", ""),
+            VRP=data.get("VRP", ""),
         )
 
     async def get_power(self) -> int:

--- a/custom_components/apsystems_ezhi_local/binary_sensor.py
+++ b/custom_components/apsystems_ezhi_local/binary_sensor.py
@@ -25,7 +25,21 @@ from .const import DOMAIN
 class EZHIBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes EZHI binary sensor entity."""
     
-    value_fn: Callable[[ReturnAlarmData], bool]
+    # bool | None, not bool: the three newest alarm fields are absent on
+    # older firmware, and "we don't know" is not the same answer as "no".
+    value_fn: Callable[[ReturnAlarmData], bool | None]
+
+
+def _alarm_flag(raw) -> bool | None:
+    """One alarm field to on/off, or None when the firmware did not report it.
+
+    The older sensors in this file compare to "1" directly and so read a
+    missing field as "off". For a field that may genuinely be absent, that
+    would assert the absence of a fault the device never denied.
+    """
+    if raw is None or str(raw) == "":
+        return None
+    return str(raw) == "1"
 
 
 ALARM_SENSORS: tuple[EZHIBinarySensorEntityDescription, ...] = (
@@ -130,6 +144,26 @@ ALARM_SENSORS: tuple[EZHIBinarySensorEntityDescription, ...] = (
         name="IRD Error",
         device_class=BinarySensorDeviceClass.PROBLEM,
         value_fn=lambda data: str(data.IRDE) == "1",
+    ),
+    # The three fields getAlarm reports but the integration never mapped.
+    # Names and meanings are the vendor app's own, not invented here.
+    EZHIBinarySensorEntityDescription(
+        key="soc_calibration",
+        name="SOC Calibration Needed",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=lambda data: _alarm_flag(data.BCC),
+    ),
+    EZHIBinarySensorEntityDescription(
+        key="battery_access_conflict",
+        name="Battery Access Conflict",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=lambda data: _alarm_flag(data.BCI),
+    ),
+    EZHIBinarySensorEntityDescription(
+        key="voltage_reset_protection",
+        name="Voltage Reset Protection",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=lambda data: _alarm_flag(data.VRP),
     ),
 )
 

--- a/custom_components/apsystems_ezhi_local/manifest.json
+++ b/custom_components/apsystems_ezhi_local/manifest.json
@@ -5,7 +5,9 @@
   "documentation": "https://github.com/kamilkosek/EZHI",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@kamilkosek"],
-  "version": "0.2.0",
+  "codeowners": [
+    "@kamilkosek"
+  ],
+  "version": "0.3.0",
   "iot_class": "local_polling"
 }

--- a/tests/test_alarm_flags.py
+++ b/tests/test_alarm_flags.py
@@ -1,0 +1,109 @@
+"""Unit tests for the alarm fields getAlarm reports but the integration
+did not map.
+
+No network and no Home Assistant: the two modules are loaded by path, and
+binary_sensor.py's helper is pulled out of the source so importing the whole
+Home Assistant entity stack is not needed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_COMPONENT = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "apsystems_ezhi_local"
+)
+
+# api.py imports aiohttp at module level, but nothing here makes an HTTP call --
+# only the alarm dataclass is under test. A stub keeps this suite runnable with
+# a bare `python3 -m pytest`, no virtualenv and no third-party install. The
+# names below are the ones api.py touches in its except clauses; they are only
+# evaluated if a request path runs, which these tests never take.
+if "aiohttp" not in sys.modules:
+    _aiohttp = types.ModuleType("aiohttp")
+    _aiohttp.ClientError = type("ClientError", (Exception,), {})
+    _aiohttp.ClientSession = object
+    sys.modules["aiohttp"] = _aiohttp
+
+_spec = importlib.util.spec_from_file_location("ezhi_api", _COMPONENT / "api.py")
+api = importlib.util.module_from_spec(_spec)
+# @dataclass looks its own module up in sys.modules while building the class.
+sys.modules["ezhi_api"] = api
+_spec.loader.exec_module(api)
+
+_source = (_COMPONENT / "binary_sensor.py").read_text()
+_namespace: dict = {}
+exec(  # noqa: S102 - the alternative is importing all of homeassistant
+    _source[_source.index("def _alarm_flag") : _source.index("ALARM_SENSORS")],
+    _namespace,
+)
+alarm_flag = _namespace["_alarm_flag"]
+
+
+# The full payload of a live EZHI 1.9.0.16, captured 2026-08-01.
+LIVE_PAYLOAD = {
+    "BatLTP": "0", "BatHTP": "0", "BatCE": "0", "BatHV": "0", "BatLV": "0",
+    "BatHI": "0", "BatE": "0", "DTP": "0", "EE": "0", "SBS": "0", "ACA": "0",
+    "OfOI": "0", "PvHV": "0", "PvOC": "0", "IRDE": "0", "PVWE": "0",
+    "OfGS": "0", "BCC": "0", "BCI": "0", "VRP": "0",
+}
+
+
+def _parse(payload: dict) -> api.ReturnAlarmData:
+    """What get_alarm does to a response body, without the HTTP round trip."""
+    return api.ReturnAlarmData(
+        **{
+            name: payload.get(name, "" if name in ("BCC", "BCI", "VRP") else "0")
+            for name in api.ReturnAlarmData.__dataclass_fields__
+        }
+    )
+
+
+def test_the_device_reports_twenty_alarm_fields():
+    """17 were mapped; getAlarm sends 20."""
+    assert len(api.ReturnAlarmData.__dataclass_fields__) == 20
+    for field in ("BCC", "BCI", "VRP"):
+        assert field in api.ReturnAlarmData.__dataclass_fields__
+
+
+def test_live_payload_parses_with_no_alarm_active():
+    alarms = _parse(LIVE_PAYLOAD)
+    assert (alarms.BCC, alarms.BCI, alarms.VRP) == ("0", "0", "0")
+    assert not any(
+        str(getattr(alarms, f)) == "1" for f in api.ReturnAlarmData.__dataclass_fields__
+    )
+
+
+def test_a_raised_alarm_reads_as_on():
+    alarms = _parse({**LIVE_PAYLOAD, "BCI": "1"})
+    assert alarm_flag(alarms.BCI) is True
+
+
+def test_firmware_without_the_field_reads_as_unknown_not_as_no_fault():
+    """The point of the "" default.
+
+    Older firmware simply does not send these. Reporting "off" would assert
+    the absence of a fault the device never denied -- and for BCI, a battery
+    access conflict, that assertion has consequences.
+    """
+    older_firmware = {k: v for k, v in LIVE_PAYLOAD.items() if k not in ("BCC", "BCI", "VRP")}
+    alarms = _parse(older_firmware)
+
+    assert (alarms.BCC, alarms.BCI, alarms.VRP) == ("", "", "")
+    assert alarm_flag(alarms.BCI) is None
+    assert alarm_flag(alarms.BCC) is None
+    assert alarm_flag(alarms.VRP) is None
+
+
+def test_alarm_flag_edge_cases():
+    assert alarm_flag("1") is True
+    assert alarm_flag("0") is False
+    assert alarm_flag(1) is True
+    assert alarm_flag(0) is False
+    assert alarm_flag("") is None
+    assert alarm_flag(None) is None
+    # Anything the device could send that is neither "1" nor absent is not an
+    # alarm -- guessing "on" here would be a false problem report.
+    assert alarm_flag("unexpected") is False


### PR DESCRIPTION
`getAlarm` returns **20** fields. The integration maps 17. This adds the other three.

Verified against a live EZHI 1.9.0.16 on 2026-08-01 — the device sends them alongside the rest:

```json
{"BatLTP":"0", ..., "OfGS":"0", "BCC":"0", "BCI":"0", "VRP":"0"}
```

| Field | Sensor | Meaning |
|-------|--------|---------|
| `BCC` | SOC Calibration Needed | The battery SOC reading is off; charge to 100 % to recalibrate. |
| `BCI` | Battery Access Conflict | A battery is connected while the inverter runs in battery-free mode. |
| `VRP` | Voltage Reset Protection | PV input too low, or protection after a grid anomaly/overload — a restart is needed and can take several minutes. |

Names and descriptions are the vendor app's own strings, not invented here.

## One deliberate difference from the existing 17

These three default to `""` instead of `"0"`, and a small `_alarm_flag` helper maps that to `None`.

The existing sensors compare to `"1"` directly, so a field the firmware does not send reads as **off**. For fields that have been there since the beginning that is fine. For three fields being added now, it would mean older firmware confidently reporting "no fault" for something the device never mentioned — and for a *battery access conflict* that is a claim worth not making by accident. So absent reads as `unknown`, present reads as on/off.

The existing 17 are untouched.

## Tests

`tests/test_alarm_flags.py`, runnable with a bare `python3 -m pytest` — no virtualenv, no third-party install:

```
python3 -m pytest tests/test_alarm_flags.py -q
```

`aiohttp` is stubbed in the test module because only the alarm dataclass is under test and nothing makes an HTTP call. The live payload above is included as a fixture.

## Compatibility

Purely additive. Three new binary sensors, no change to any existing entity, unique ID or behaviour. Local API only — no cloud, no new dependency, no config change.
