### PR TITLE
Set has_entity_name so the device name is not part of every entity name

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,11 @@ the file into the raw configuration editor (pencil → three dots → Raw
 configuration editor).
 
 **Both files assume the integration was added with the name `ezhi`.** Replace
-that throughout if you used something else — but note the prefixes are not
-uniform: the local sensors are `sensor.ezhi_…`, while the cloud entities and
-the local power number carry an extra `apsystems_`. The exact ids for your
-install are on the device page.
+that throughout if you used something else. Upgrading from 0.4.0 or earlier?
+Entity ids are handed out once, at first registration, so an existing install
+keeps the ones it already has — and there the cloud entities and the local
+power number carry an extra `apsystems_` (`switch.apsystems_ezhi_backup_power`).
+The exact ids for your install are on the device page.
 
 The control section is marked for deletion if you do not use cloud control. It
 is not hidden by a conditional card on purpose: the frontend's condition check
@@ -270,6 +271,20 @@ rather than a wrong path.
 - **Stale data**: Try reducing the update interval in the integration options
 
 ## Changelog
+
+### v0.5.0
+
+- **Fixed:** every entity set `has_entity_name`, so the device name is no
+  longer baked into the entity name as well — the frontend showed
+  "EZHI APsystems EZHI Backup Power" where it puts device and entity side by
+  side
+- New installs get uniform entity ids: the cloud entities and the local power
+  number lose their extra `apsystems_` prefix (`switch.ezhi_backup_power`, not
+  `switch.apsystems_ezhi_backup_power`)
+- **Existing installs are unaffected.** Entity ids are assigned once, at first
+  registration; a later name change only updates the registry's stored name.
+  Automations, dashboards and history keep working — the example dashboards
+  now match a fresh install, so check the device page for your own ids
 
 ### v0.4.0
 

--- a/custom_components/apsystems_ezhi_local/binary_sensor.py
+++ b/custom_components/apsystems_ezhi_local/binary_sensor.py
@@ -192,6 +192,10 @@ class EZHIAlarmBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     entity_description: EZHIBinarySensorEntityDescription
 
+    # See EzhiCloudEntity: with this set the name is entity_description.name
+    # alone, and Home Assistant prefixes the device name itself.
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ApSystemsDataCoordinator,
@@ -203,7 +207,6 @@ class EZHIAlarmBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.entity_description = description
         self._device_name = device_name
         self._attr_unique_id = f"apsystems_{device_name}_{description.key}"
-        self._attr_name = f"{device_name} {description.name}"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/apsystems_ezhi_local/entity.py
+++ b/custom_components/apsystems_ezhi_local/entity.py
@@ -42,6 +42,11 @@ class EzhiCloudEntity(CoordinatorEntity):
     copied verbatim into all three.
     """
 
+    # The name is the entity's alone ("Backup Power"); Home Assistant puts the
+    # device name in front of it. Baking it in here as well produced "EZHI
+    # APsystems EZHI Backup Power" wherever the frontend shows both.
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator,
@@ -51,7 +56,7 @@ class EzhiCloudEntity(CoordinatorEntity):
     ) -> None:
         super().__init__(coordinator)
         self._device_name = device_name
-        self._attr_name = f"APsystems {device_name} {name_suffix}"
+        self._attr_name = name_suffix
         self._attr_unique_id = f"apsystems_{device_name}_cloud_{unique_id_suffix}"
 
     @property

--- a/custom_components/apsystems_ezhi_local/manifest.json
+++ b/custom_components/apsystems_ezhi_local/manifest.json
@@ -8,6 +8,6 @@
   "codeowners": [
     "@kamilkosek"
   ],
-  "version": "0.4.0",
+  "version": "0.5.0",
   "iot_class": "local_polling"
 }

--- a/custom_components/apsystems_ezhi_local/number.py
+++ b/custom_components/apsystems_ezhi_local/number.py
@@ -62,13 +62,16 @@ class PowerLimit(NumberEntity):
     _attr_native_min_value = MIN_VALUE
     _attr_native_max_value = MAX_VALUE
     _attr_native_step = 10
+    # See EzhiCloudEntity: the device name comes from device_info, so the
+    # entity carries only its own half of the name.
+    _attr_has_entity_name = True
 
     def __init__(self, api: APsystemsEZHI, device_name: str, sensor_name: str, sensor_id: str):
         """Initialize the sensor."""
         self._api = api
         self._state = None
         self._device_name = device_name
-        self._name = sensor_name
+        self._attr_name = sensor_name
         self._sensor_id = sensor_id
 
     async def async_update(self):
@@ -88,11 +91,6 @@ class PowerLimit(NumberEntity):
     def unique_id(self) -> str | None:
         """Return the unique ID of the sensor."""
         return f"apsystems_{self._device_name}_{self._sensor_id}"
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"APsystems {self._device_name} {self._name}"
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value of the power limit."""

--- a/custom_components/apsystems_ezhi_local/sensor.py
+++ b/custom_components/apsystems_ezhi_local/sensor.py
@@ -224,6 +224,10 @@ class EzhiCloudPowerLimitSensor(EzhiCloudEntity, SensorEntity):
 class BaseSensor(CoordinatorEntity, SensorEntity):
     """Representation of an APsystem sensor."""
 
+    # See EzhiCloudEntity: the device name comes from device_info, so the
+    # entity carries only its own half of the name.
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ApSystemsDataCoordinator,
@@ -235,13 +239,8 @@ class BaseSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._state = None
         self._device_name = device_name
-        self._sensor_name = sensor_name
+        self._attr_name = sensor_name
         self._sensor_id = sensor_id
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"{self._device_name} {self._sensor_name}"
 
     @property
     def state(self):

--- a/examples/dashboard-core.yaml
+++ b/examples/dashboard-core.yaml
@@ -13,10 +13,11 @@
 # ENTITY IDS
 #   This file assumes the integration was added with the name "ezhi". If you
 #   used a different name, replace "ezhi" throughout.
-#   Careful: the prefixes are not uniform. The local sensors are
-#   "sensor.ezhi_...", while the cloud entities and the local power number
-#   carry an extra "apsystems_": "switch.apsystems_ezhi_...". The exact ids
-#   for your install are listed on the device page under
+#   Upgraded from 0.4.0 or earlier? Entity ids are handed out once, at first
+#   registration, so an existing install keeps the ones it already has -- and
+#   there the cloud entities and the local power number carry an extra
+#   "apsystems_" ("switch.apsystems_ezhi_backup_power"). The exact ids for
+#   your install are listed on the device page under
 #   Settings -> Devices & Services -> APsystems EZHI -> your device.
 
 views:
@@ -86,7 +87,7 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: number.apsystems_ezhi_on_grid_power
+              - entity: number.ezhi_on_grid_power
                 name: Grid setpoint
           - type: markdown
             content: >-
@@ -114,25 +115,25 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.apsystems_ezhi_inverter_on
+              - entity: switch.ezhi_inverter_on
                 name: Inverter
-              - entity: select.apsystems_ezhi_system_mode
+              - entity: select.ezhi_system_mode
                 name: System mode
-              - entity: switch.apsystems_ezhi_backup_power
+              - entity: switch.ezhi_backup_power
                 name: Backup power (EPS)
-              - entity: switch.apsystems_ezhi_eco_mode
+              - entity: switch.ezhi_eco_mode
                 name: ECO mode
               - type: section
                 label: Limits
-              - entity: number.apsystems_ezhi_soc_minimum
+              - entity: number.ezhi_soc_minimum
                 name: SOC minimum
-              - entity: number.apsystems_ezhi_soc_maximum
+              - entity: number.ezhi_soc_maximum
                 name: SOC maximum
-              - entity: number.apsystems_ezhi_discharge_protection
+              - entity: number.ezhi_discharge_protection
                 name: Discharge protection
-              - entity: number.apsystems_ezhi_preset_output_power
+              - entity: number.ezhi_preset_output_power
                 name: Preset output power
-              - entity: sensor.apsystems_ezhi_power_limit
+              - entity: sensor.ezhi_power_limit
                 name: Output ceiling
           # Buttons, not entity rows: rows in an entities card ignore
           # tap_action.confirmation, and the 1200 W direction should not be

--- a/examples/dashboard.yaml
+++ b/examples/dashboard.yaml
@@ -8,10 +8,11 @@
 # ENTITY IDS
 #   This file assumes the integration was added with the name "ezhi". If you
 #   used a different name, replace "ezhi" throughout.
-#   Careful: the prefixes are not uniform. The local sensors are
-#   "sensor.ezhi_...", while the cloud entities and the local power number
-#   carry an extra "apsystems_": "switch.apsystems_ezhi_...". The exact ids
-#   for your install are listed on the device page under
+#   Upgraded from 0.4.0 or earlier? Entity ids are handed out once, at first
+#   registration, so an existing install keeps the ones it already has -- and
+#   there the cloud entities and the local power number carry an extra
+#   "apsystems_" ("switch.apsystems_ezhi_backup_power"). The exact ids for
+#   your install are listed on the device page under
 #   Settings -> Devices & Services -> APsystems EZHI -> your device.
 #
 # REQUIRED CUSTOM CARDS (install via HACS first)
@@ -96,7 +97,7 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: number.apsystems_ezhi_on_grid_power
+              - entity: number.ezhi_on_grid_power
                 name: Grid setpoint
           - type: markdown
             content: >-
@@ -124,25 +125,25 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.apsystems_ezhi_inverter_on
+              - entity: switch.ezhi_inverter_on
                 name: Inverter
-              - entity: select.apsystems_ezhi_system_mode
+              - entity: select.ezhi_system_mode
                 name: System mode
-              - entity: switch.apsystems_ezhi_backup_power
+              - entity: switch.ezhi_backup_power
                 name: Backup power (EPS)
-              - entity: switch.apsystems_ezhi_eco_mode
+              - entity: switch.ezhi_eco_mode
                 name: ECO mode
               - type: section
                 label: Limits
-              - entity: number.apsystems_ezhi_soc_minimum
+              - entity: number.ezhi_soc_minimum
                 name: SOC minimum
-              - entity: number.apsystems_ezhi_soc_maximum
+              - entity: number.ezhi_soc_maximum
                 name: SOC maximum
-              - entity: number.apsystems_ezhi_discharge_protection
+              - entity: number.ezhi_discharge_protection
                 name: Discharge protection
-              - entity: number.apsystems_ezhi_preset_output_power
+              - entity: number.ezhi_preset_output_power
                 name: Preset output power
-              - entity: sensor.apsystems_ezhi_power_limit
+              - entity: sensor.ezhi_power_limit
                 name: Output ceiling
           # Buttons, not entity rows: rows in an entities card ignore
           # tap_action.confirmation, and the 1200 W direction should not be


### PR DESCRIPTION
Offered in #11 as a separate change ("the device name ends up in the entity name twice"); this is that change on its own, on top of current `main`.

## The problem

Every entity class builds its own name out of the device name, and then hands Home Assistant a `device_info` carrying that same name:

| | name | device_info.name |
|---|---|---|
| `entity.py` (cloud) | `f"APsystems {device} {suffix}"` | `device` |
| `sensor.py` `BaseSensor` | `f"{device} {sensor_name}"` | `device` |
| `binary_sensor.py` | `f"{device} {description.name}"` | `device` |
| `number.py` `PowerLimit` | `f"APsystems {device} {name}"` | `device` |

Wherever the frontend puts the two side by side, that reads back as **"EZHI APsystems EZHI Backup Power"**.

The entity ids drifted apart for the same reason. On a fresh install named `ezhi` you get `sensor.ezhi_battery_power` but `switch.apsystems_ezhi_backup_power` — same device, two prefix conventions, because each class picked its own.

## The change

`_attr_has_entity_name = True`, and the names drop the device half: `"Backup Power"`, not `"APsystems ezhi Backup Power"`. Home Assistant puts the device name in front itself.

Two of the four built the name in a `name` property, which overrides `Entity.name` outright and would have ignored the flag — both now set `_attr_name` in `__init__`. `binary_sensor.py` drops its `_attr_name` altogether: with the flag set, `Entity.name` falls back to `entity_description.name`, which all 20 alarm descriptions already have.

Unique ids are untouched.

## Existing installs keep their entity ids

Entity ids are assigned once, at first registration; `async_get_or_create` matches on `(domain, platform, unique_id)` and only updates the stored name.

Verified rather than assumed, on a live install with all 47 entities — entity registry dumped before, integration deployed, Home Assistant restarted, registry dumped again:

```
unique_ids before 47, after 47   (none added, none dropped)
ENTITY_ID CHANGES: 0
has_entity_name:  False -> True
original_name:    "EZHI AC Abnormal" -> "AC Abnormal"
friendly_name:    "EZHI APsystems EZHI Backup Power" -> "EZHI Backup Power"
47/47 entities have a live state, none unavailable
```

Automations, dashboards and history are unaffected.

## Fresh installs do change

They become uniform: the cloud entities and the local power number lose the extra `apsystems_`, so everything is `<device>_<entity>`.

| before | after |
|---|---|
| `switch.apsystems_ezhi_backup_power` | `switch.ezhi_backup_power` |
| `number.apsystems_ezhi_soc_minimum` | `number.ezhi_soc_minimum` |
| `sensor.apsystems_ezhi_power_limit` | `sensor.ezhi_power_limit` |
| `sensor.ezhi_battery_power` | unchanged |

Ten ids in total. Both example dashboards hardcode ids and are updated to match a fresh install, with a note for anyone upgrading; the README passage warning about the non-uniform prefixes now describes only the pre-0.5.0 case.

Manifest and changelog bumped to 0.5.0 — say the word if you would rather set that yourself.

## Tests

`93 passed`. The suite has no Home Assistant harness, so it does not cover the entity classes; the live registry diff above is the check for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
